### PR TITLE
Resource charts

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -126,6 +126,9 @@ fos_user:
     db_driver: orm # other valid values are 'mongodb', 'couchdb' and 'propel'
     firewall_name: main
     user_class: AppBundle\Entity\User
+    from_email:
+        address: "%email_sender_address%"
+        sender_name: "%email_sender_name%"
     registration:
         confirmation:
             enabled: true

--- a/src/AppBundle/Resources/public/js/app.deck_charts.js
+++ b/src/AppBundle/Resources/public/js/app.deck_charts.js
@@ -7,28 +7,28 @@
 	});
 
 
-var charts = [],
-	faction_colors = {
-
-		seeker :
-			'#e3d852',
-
-		neutral :
-			'#cfcfcf',
-
-		guardian :
-			'#1d7a99',
-
-		survivor :
-			'#c00106',
-
-		rogue :
-			'#509f16',
-
-		mystic :
-			'#ae1eae'
-
-	};
+	var charts = [],
+		faction_colors = {
+	
+			leadership:
+				'#2b80c5',
+	
+			aggression :
+				'#cc3038',
+	
+			protection :
+				'#107116',
+	
+			basic :
+				'#808080',
+	
+			justice :
+				'#c0c000',
+	
+			hero :
+				'#AB006A'
+	
+		};
 
 deck_charts.chart_faction = function chart_faction() {
 	var factions = {};
@@ -146,95 +146,194 @@ deck_charts.chart_cost = function chart_cost() {
 }
 
 
+//------------------Resource chart-------------------//
 deck_charts.chart_resource = function chart_resource() {
-	
+
+	//setting properties of all the four resource icons in game
+
 	var icons = {};
-	icons['physical'] = {code: "physical", "name": "Physical",color: "#661e09", count: 0, icondict:{single:0, double:0, triple:0}};
-	icons['mental'] = {code: "mental", "name": "Mental", color: "#003961", count: 0, icondict:{single:0, double:0, triple:0}};
-	icons['energy'] = {code: "energy", "name": "Energy", color:"#ff8f3f", count: 0, icondict:{single:0, double:0, triple:0}};
-	icons['wild'] = {code: "wild", "name": "Wild", color: "#00543a", count: 0, icondict:{single:0, double:0, triple:0}};
+	icons['physical'] = {
+		code: "physical",
+		"name": "Physical",
+		color: "#661e09",
+		count: 0,
+		HeroCardsCounter: 0,
+		IconCount: {
+			single: 0,
+			double: 0,
+			triple: 0
+		}
+	};
+	icons['mental'] = {
+		code: "mental",
+		"name": "Mental",
+		color: "#003961",
+		count: 0,
+		HeroCardsCounter: 0,
+		IconCount: {
+			single: 0,
+			double: 0,
+			triple: 0
+		}
+	};
+	icons['energy'] = {
+		code: "energy",
+		"name": "Energy",
+		color: "#ff8f3f",
+		count: 0,
+		HeroCardsCounter: 0,
+		IconCount: {
+			single: 0,
+			double: 0,
+			triple: 0
+		}
+	};
+	icons['wild'] = {
+		code: "wild",
+		"name": "Wild",
+		color: "#00543a",
+		count: 0,
+		HeroCardsCounter: 0,
+		IconCount: {
+			single: 0,
+			double: 0,
+			triple: 0
+		}
+	};
+	
+	//checking every card in the deck (without identity cards and etc.) for number of resource icons
+	//checking also if these icons are on hero cards or not 
 	var draw_deck = app.deck.get_physical_draw_deck();
-	console.log(draw_deck)
-	draw_deck.forEach(function (card) {
-		if (card.resource_physical && card.resource_physical > 0){
-			switch(card.resource_physical){
+	draw_deck.forEach(function(card) {
+		if (card.resource_physical && card.resource_physical > 0) {
+			switch (card.resource_physical) {
 				case 1:
 					icons['physical'].count += card.indeck * card.resource_physical;
-					icons['physical'].icondict.single+=card.indeck;
+					icons['physical'].IconCount.single += card.indeck;
 					break;
 				case 2:
 					icons['physical'].count += card.indeck * card.resource_physical;
-					icons['physical'].icondict.double+=card.indeck;
+					icons['physical'].IconCount.double += card.indeck;
+					break;
+				case 3:
+					icons['physical'].count += card.indeck * card.resource_physical;
+					icons['physical'].IconCount.triple += card.indeck;
 					break;
 			}
+			if (card.faction_code === "hero") {
+				icons['physical'].HeroCardsCounter += card.indeck * card.resource_physical;
+			}
 		}
-		if (card.resource_mental && card.resource_mental > 0){
-			switch(card.resource_mental){
+		if (card.resource_mental && card.resource_mental > 0) {
+			switch (card.resource_mental) {
 				case 1:
 					icons['mental'].count += card.indeck * card.resource_mental;
-					icons['mental'].icondict.single+=card.indeck;
+					icons['mental'].IconCount.single += card.indeck;
 					break;
 				case 2:
 					icons['mental'].count += card.indeck * card.resource_mental;
-					icons['mental'].icondict.double+=card.indeck;
+					icons['mental'].IconCount.double += card.indeck;
+					break;
+				case 3:
+					icons['mental'].count += card.indeck * card.resource_mental;
+					icons['mental'].IconCount.triple += card.indeck;
 					break;
 			}
+			if (card.faction_code === "hero") {
+				icons['mental'].HeroCardsCounter += card.indeck * card.resource_mental;
+			}
 		}
-		if (card.resource_energy && card.resource_energy > 0){
-			switch(card.resource_energy){
+		if (card.resource_energy && card.resource_energy > 0) {
+			switch (card.resource_energy) {
 				case 1:
 					icons['energy'].count += card.indeck * card.resource_energy;
-					icons['energy'].icondict.single+=card.indeck;
+					icons['energy'].IconCount.single += card.indeck;
 					break;
 				case 2:
 					icons['energy'].count += card.indeck * card.resource_energy;
-					icons['energy'].icondict.double+=card.indeck;
+					icons['energy'].IconCount.double += card.indeck;
+					break;
+				case 3:
+					icons['energy'].count += card.indeck * card.resource_energy;
+					icons['energy'].IconCount.triple += card.indeck;
 					break;
 			}
+			if (card.faction_code === "hero") {
+				icons['energy'].HeroCardsCounter += card.indeck * card.resource_energy;
+			}
 		}
-		if (card.resource_wild && card.resource_wild > 0){
-			switch(card.resource_wild){
+		if (card.resource_wild && card.resource_wild > 0) {
+			switch (card.resource_wild) {
 				case 1:
 					icons['wild'].count += card.indeck * card.resource_wild;
-					icons['wild'].icondict.single+=card.indeck;
+					icons['wild'].IconCount.single += card.indeck;
 					break;
 				case 2:
 					icons['wild'].count += card.indeck * card.resource_wild;
-					icons['wild'].icondict.double+=card.indeck;
+					icons['wild'].IconCount.double += card.indeck;
 					break;
+				case 3:
+					icons['wild'].count += card.indeck * card.resource_wild;
+					icons['wild'].IconCount.triple += card.indeck;
+					break;
+			}
+			if (card.faction_code === "hero") {
+				icons['wild'].HeroCardsCounter += card.indeck * card.resource_wild;
 			}
 		}
 	})
+	
+	//creating three datasets for X axis in the chart
+	//HeroData is used in stacked columns
+	//data is used in normal columns
+	//DrillData is used in drilldown columns
+	var HeroData = [];
 	var data = [];
-	drilllist=[];
-	_.each(_.values(icons), function (icon) {
+	var DrillData = [];
+	_.each(_.values(icons), function(icon) {
 		data.push({
 			name: icon.name,
-			label: '<span class="icon icon-'+icon.code+' color-'+icon.code+'"></span>',
+			label: '<span class="icon icon-' + icon.code + ' color-' + icon.code + '"></span>',
 			color: icon.color,
 			y: icon.count,
 			code: icon.code,
-			drilldown: "lama",
-		});for (var key in icon.icondict) {
-			let counter= icon.icondict[key];
-				switch(key){
-					case "single":
-						repeaticon =1
-						break;
-					case "double":
-						repeaticon = 2
-						break;
-					case "triple":
-						repeaticon = 3
-						break;
-				}
-			if (counter>0){
-			let icokey= key+" "+icon.code;
-			let label = '<span class="icon icon-'+icon.code+' color-'+icon.code+'"></span>'
-			drilllist.push({name: icokey,color:icon.color, y:counter, label: label.repeat(repeaticon) })}}
+			drilldown: "MultipleIconsChart",
+		});
+		HeroData.push({
+			name: icon.name,
+			label: '<span class="icon icon-' + icon.code + ' color-' + icon.code + '"></span>',
+			y: icon.HeroCardsCounter,
+		})
+		for (var key in icon.IconCount) {
+			let counter = icon.IconCount[key];
+			switch (key) {
+				case "single":
+					RepeatIcon = 1
+					break;
+				case "double":
+					RepeatIcon = 2
+					break;
+				case "triple":
+					RepeatIcon = 3
+					break;
+			}
+			if (counter > 0) {
+				let IconKey = key + " " + icon.code;
+				let label = '<span class="icon icon-' + icon.code + ' color-' + icon.code + '"></span>'
+				DrillData.push({
+					name: IconKey,
+					color: icon.color,
+					y: counter,
+					label: label.repeat(RepeatIcon)
+				})
+			}
+		}
 	})
-	console.log(data)
-	data = _.flatten(data).map(function (value) { return value || 0; });
+	data = _.flatten(data).map(function(value) {
+		return value || 0;
+	});
+	
+	//setting all the parameters for the chart
 	$("#deck-chart-resource").highcharts({
 		chart: {
 			type: 'column'
@@ -253,8 +352,8 @@ deck_charts.chart_resource = function chart_resource() {
 			title: {
 				text: null
 			}
-		},{
-			categories: _.pluck(drilllist, 'label'),
+		}, {
+			categories: _.pluck(DrillData, 'label'),
 			labels: {
 				useHTML: true
 			},
@@ -278,26 +377,34 @@ deck_charts.chart_resource = function chart_resource() {
 			showInLegend: false,
 			data: data,
 			xAxis: 0
+		}, {
+			type: "column",
+			animation: false,
+			name: '# of resources from hero cards',
+			showInLegend: false,
+			data: HeroData,
+			xAxis: 0
 		}],
-		drilldown:{
-			drillUpButton:{
-				position:{
-					y:0,
-					x:0
+		drilldown: {
+			drillUpButton: {
+				position: {
+					y: 0,
+					x: 0
 				},
 
 			},
-			series:[{
+			series: [{
 				showInLegend: false,
 				name: '# of cards',
 				xAxis: 1,
-				id: "lama",
-				data: drilllist
+				id: "MultipleIconsChart",
+				data: DrillData
 
 			}]
 		},
 		plotOptions: {
 			column: {
+				stacking: 'normal',
 				borderWidth: 0,
 				groupPadding: 0,
 				shadow: false

--- a/src/AppBundle/Resources/public/js/app.deck_charts.js
+++ b/src/AppBundle/Resources/public/js/app.deck_charts.js
@@ -2,7 +2,7 @@
 
 	Highcharts.setOptions({
 		lang: {
-			drillUpText: '<< Back'
+			drillUpText: 'X'
 		}
 	});
 
@@ -395,7 +395,11 @@ deck_charts.chart_resource = function chart_resource() {
 					y: 0,
 					x: 0
 				},
-
+				theme:{
+					width: 7,
+					height: 12,
+				},
+				relativeTo: 'spacingBox',
 			},
 			series: [{
 				showInLegend: false,

--- a/src/AppBundle/Resources/public/js/app.deck_charts.js
+++ b/src/AppBundle/Resources/public/js/app.deck_charts.js
@@ -1,5 +1,12 @@
 (function app_deck_charts(deck_charts, $) {
 
+	Highcharts.setOptions({
+		lang: {
+			drillUpText: '<< Back'
+		}
+	});
+
+
 var charts = [],
 	faction_colors = {
 
@@ -140,39 +147,94 @@ deck_charts.chart_cost = function chart_cost() {
 
 
 deck_charts.chart_resource = function chart_resource() {
-
+	
 	var icons = {};
-	icons['physical'] = {code: "physical", "name": "Physical", count: 0};
-	icons['mental'] = {code: "mental", "name": "Mental", count: 0};
-	icons['energy'] = {code: "energy", "name": "Energy", count: 0};
-	icons['wild'] = {code: "wild", "name": "Wild", count: 0};
+	icons['physical'] = {code: "physical", "name": "Physical",color: "#661e09", count: 0, icondict:{single:0, double:0, triple:0}};
+	icons['mental'] = {code: "mental", "name": "Mental", color: "#003961", count: 0, icondict:{single:0, double:0, triple:0}};
+	icons['energy'] = {code: "energy", "name": "Energy", color:"#ff8f3f", count: 0, icondict:{single:0, double:0, triple:0}};
+	icons['wild'] = {code: "wild", "name": "Wild", color: "#00543a", count: 0, icondict:{single:0, double:0, triple:0}};
 	var draw_deck = app.deck.get_physical_draw_deck();
+	console.log(draw_deck)
 	draw_deck.forEach(function (card) {
 		if (card.resource_physical && card.resource_physical > 0){
-			icons['physical'].count += card.indeck * card.resource_physical;
+			switch(card.resource_physical){
+				case 1:
+					icons['physical'].count += card.indeck * card.resource_physical;
+					icons['physical'].icondict.single+=card.indeck;
+					break;
+				case 2:
+					icons['physical'].count += card.indeck * card.resource_physical;
+					icons['physical'].icondict.double+=card.indeck;
+					break;
+			}
 		}
 		if (card.resource_mental && card.resource_mental > 0){
-			icons['mental'].count += card.indeck * card.resource_mental;
+			switch(card.resource_mental){
+				case 1:
+					icons['mental'].count += card.indeck * card.resource_mental;
+					icons['mental'].icondict.single+=card.indeck;
+					break;
+				case 2:
+					icons['mental'].count += card.indeck * card.resource_mental;
+					icons['mental'].icondict.double+=card.indeck;
+					break;
+			}
 		}
 		if (card.resource_energy && card.resource_energy > 0){
-			icons['energy'].count += card.indeck * card.resource_energy;
+			switch(card.resource_energy){
+				case 1:
+					icons['energy'].count += card.indeck * card.resource_energy;
+					icons['energy'].icondict.single+=card.indeck;
+					break;
+				case 2:
+					icons['energy'].count += card.indeck * card.resource_energy;
+					icons['energy'].icondict.double+=card.indeck;
+					break;
+			}
 		}
 		if (card.resource_wild && card.resource_wild > 0){
-			icons['wild'].count += card.indeck * card.resource_wild;
+			switch(card.resource_wild){
+				case 1:
+					icons['wild'].count += card.indeck * card.resource_wild;
+					icons['wild'].icondict.single+=card.indeck;
+					break;
+				case 2:
+					icons['wild'].count += card.indeck * card.resource_wild;
+					icons['wild'].icondict.double+=card.indeck;
+					break;
+			}
 		}
 	})
-
 	var data = [];
+	drilllist=[];
 	_.each(_.values(icons), function (icon) {
 		data.push({
 			name: icon.name,
 			label: '<span class="icon icon-'+icon.code+' color-'+icon.code+'"></span>',
-			//color: faction_colors[faction.code],
-			y: icon.count
-		});
+			color: icon.color,
+			y: icon.count,
+			code: icon.code,
+			drilldown: "lama",
+		});for (var key in icon.icondict) {
+			let counter= icon.icondict[key];
+				switch(key){
+					case "single":
+						repeaticon =1
+						break;
+					case "double":
+						repeaticon = 2
+						break;
+					case "triple":
+						repeaticon = 3
+						break;
+				}
+			if (counter>0){
+			let icokey= key+" "+icon.code;
+			let label = '<span class="icon icon-'+icon.code+' color-'+icon.code+'"></span>'
+			drilllist.push({name: icokey,color:icon.color, y:counter, label: label.repeat(repeaticon) })}}
 	})
+	console.log(data)
 	data = _.flatten(data).map(function (value) { return value || 0; });
-		
 	$("#deck-chart-resource").highcharts({
 		chart: {
 			type: 'column'
@@ -183,7 +245,7 @@ deck_charts.chart_resource = function chart_resource() {
 		subtitle: {
 			text: ""
 		},
-		xAxis: {
+		xAxis: [{
 			categories: _.pluck(data, 'label'),
 			labels: {
 				useHTML: true
@@ -191,7 +253,15 @@ deck_charts.chart_resource = function chart_resource() {
 			title: {
 				text: null
 			}
-		},
+		},{
+			categories: _.pluck(drilllist, 'label'),
+			labels: {
+				useHTML: true
+			},
+			title: {
+				text: null
+			}
+		}],
 		yAxis: {
 			min: 0,
 			allowDecimals: false,
@@ -206,8 +276,26 @@ deck_charts.chart_resource = function chart_resource() {
 			animation: false,
 			name: '# of resources',
 			showInLegend: false,
-			data: data
+			data: data,
+			xAxis: 0
 		}],
+		drilldown:{
+			drillUpButton:{
+				position:{
+					y:0,
+					x:0
+				},
+
+			},
+			series:[{
+				showInLegend: false,
+				name: '# of cards',
+				xAxis: 1,
+				id: "lama",
+				data: drilllist
+
+			}]
+		},
 		plotOptions: {
 			column: {
 				borderWidth: 0,

--- a/src/AppBundle/Resources/public/js/app.deck_charts.js
+++ b/src/AppBundle/Resources/public/js/app.deck_charts.js
@@ -222,6 +222,7 @@ deck_charts.chart_resource = function chart_resource() {
 			}
 			if (card.faction_code === "hero") {
 				icons['physical'].HeroCardsCounter += card.indeck * card.resource_physical;
+				icons['physical'].count -= card.indeck * card.resource_physical;
 			}
 		}
 		if (card.resource_mental && card.resource_mental > 0) {
@@ -241,6 +242,7 @@ deck_charts.chart_resource = function chart_resource() {
 			}
 			if (card.faction_code === "hero") {
 				icons['mental'].HeroCardsCounter += card.indeck * card.resource_mental;
+				icons['mental'].count -= card.indeck * card.resource_mental;
 			}
 		}
 		if (card.resource_energy && card.resource_energy > 0) {
@@ -260,6 +262,7 @@ deck_charts.chart_resource = function chart_resource() {
 			}
 			if (card.faction_code === "hero") {
 				icons['energy'].HeroCardsCounter += card.indeck * card.resource_energy;
+				icons['energy'].count -= card.indeck * card.resource_energy;
 			}
 		}
 		if (card.resource_wild && card.resource_wild > 0) {
@@ -279,6 +282,7 @@ deck_charts.chart_resource = function chart_resource() {
 			}
 			if (card.faction_code === "hero") {
 				icons['wild'].HeroCardsCounter += card.indeck * card.resource_wild;
+				icons['wild'].count -= card.indeck * card.resource_wild;
 			}
 		}
 	})

--- a/src/AppBundle/Resources/views/layout.html.twig
+++ b/src/AppBundle/Resources/views/layout.html.twig
@@ -153,7 +153,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/0.3.5/marked.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.textcomplete/0.2.2/jquery.textcomplete.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/4.1.7/highcharts.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/drilldown.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.9.0/js/bootstrap-markdown.min.js"></script>
     <script type="text/javascript">
     var app = {};


### PR DESCRIPTION
- Added stacked columns with hero cards resource count in deck

- After clicking any of the columns, charts show the distribution of the resource icons among the cards.

- needed to import new module _**drilldown.js**_ and it depends on a newer version of _**highcharts.js**_

- Fixed colours of columns for Resource charts and Faction charts

![image](https://user-images.githubusercontent.com/24622057/75286231-74c8d680-5818-11ea-84a1-05061ed1b518.png)
![image](https://user-images.githubusercontent.com/24622057/75286410-ccffd880-5818-11ea-8346-dcd3b3ab74b7.png)

