### PR TITLE
Fix margin problem on mobile

### DIFF
--- a/src/AppBundle/Resources/views/Default/index.html.twig
+++ b/src/AppBundle/Resources/views/Default/index.html.twig
@@ -57,6 +57,11 @@
 	.box5 {
 		border-width: 2px 2px 2px 2px;
 	}
+	@media (min-width:992px){
+		.right-col {
+			margin-left: 5px;
+		}
+	}
 
 
 </style>
@@ -104,7 +109,7 @@
 		{% endfor %}
 	</div>
 	
-	<div class="row col-md-6" style="margin-left: 5px;">
+	<div class="row col-md-6 right-col">
 		<h3>Recent Decks</h3>
 		{% for data in decklists_by_recent %}
 		<div style="margin-bottom:10px; ">


### PR DESCRIPTION
It fixes this removing extra margin under `md` viewport:

![Screen Shot 2021-09-21 at 17 42 03](https://user-images.githubusercontent.com/1442934/134202682-536680ea-2794-4a16-9d9c-467e1ca5ad8f.png)
