### PR TITLE
Fix translation import to get card sets translations

### DIFF
--- a/src/AppBundle/Command/ImportTransCommand.php
+++ b/src/AppBundle/Command/ImportTransCommand.php
@@ -52,7 +52,7 @@ class ImportTransCommand extends ContainerAwareCommand
 		}
 
 		//$things = ['faction', 'type', 'subtype', 'cycle', 'pack', 'campaign', 'scenario', 'encounter'];
-		$things = ['faction', 'type', 'subtype', 'pack'];
+		$things = ['faction', 'type', 'subtype', 'pack', ['set', 'cardset']];
 
 		foreach($locales as $locale)
 		{
@@ -60,9 +60,18 @@ class ImportTransCommand extends ContainerAwareCommand
 			$output->writeln("Importing translations for <info>${locale}</info>");
 			foreach($things as $thing)
 			{
-				$output->writeln("Importing translations for <info>${thing}s</info> in <info>${locale}</info>");
-				$fileInfo = $this->getFileInfo("${path}/translations/${locale}", "${thing}s.json");
-				$this->importThingsJsonFile($fileInfo, $locale, $thing);
+				$jsonName = null;
+				$entityName = null;
+				if(!is_array($thing)) {
+					$jsonName = $thing;
+					$entityName = $thing;
+				} else {
+					$jsonName = $thing[0];
+					$entityName = $thing[1];
+				}
+				$output->writeln("Importing translations for <info>${jsonName}s</info> in <info>${locale}</info>");
+				$fileInfo = $this->getFileInfo("${path}/translations/${locale}", "${jsonName}s.json");
+				$this->importThingsJsonFile($fileInfo, $locale, $entityName);
 			}
 			$this->em->flush();
 

--- a/src/AppBundle/Entity/Cardset.php
+++ b/src/AppBundle/Entity/Cardset.php
@@ -5,7 +5,7 @@ namespace AppBundle\Entity;
 /**
  * Cardset
  */
-class Cardset
+class Cardset implements \Gedmo\Translatable\Translatable, \Serializable
 {
     public function serialize() {
         return [
@@ -171,5 +171,15 @@ class Cardset
     public function getCardSetType()
     {
         return $this->cardset_type;
+    }
+
+    /*
+     * I18N vars
+     */
+    private $locale = 'en';
+
+    public function setTranslatableLocale($locale)
+    {
+        $this->locale = $locale;
     }
 }

--- a/src/AppBundle/Resources/config/doctrine/Cardset.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Cardset.orm.yml
@@ -2,6 +2,9 @@ AppBundle\Entity\Cardset:
     type: entity
     table: Cardset
     repositoryClass: AppBundle\Repository\CardsetRepository
+    gedmo:
+        translation:
+        locale: locale
     manyToOne:
         cardset_type:
             targetEntity: Cardsettype


### PR DESCRIPTION
Hi,

I've just made an edit of the import command to import correctly card sets translations and I've updated the model/orm files to use them correctly. On my local copy of the website it works really good !

Hope you can merge this fix soon, I use your api to code an app and this update will be really useful for my use :)