### PR TITLE
Change pack list to support cards from more than 2 packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This guide assumes you know how to use the command-line and that your machine ha
 - clone the repo somewhere
 - cd to it
 - run `composer install` (at the end it will ask for the database configuration parameters)
+- if `composer install` fails with version issues, you may need to run `composer self-update --1` to downgrade to composer version 1
 - run `php bin/console doctrine:database:create`
 - run `php bin/console doctrine:schema:create`
 - checkout the card data from https://github.com/zzorba/marvelsdb-json-data

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -403,71 +403,59 @@ deck.check_limit = function get_aspect_count(limit) {
  * @memberOf deck
  */
 deck.get_included_packs = function get_included_packs() {
-	var cards = deck.get_cards();
-	var nb_packs = {};
+	var cards = deck.get_cards()
 
-	var requirements = [];
-	var req_hash = {};
-	var shared_req = [];
-	cards.forEach(function (card) {
-		if (card.hidden) {
-			return
+	// Set up a list of all of the packs that are the only pack where a card is available
+	// and a list of arrays where there are a choice of pack to get a given card
+	// for example Chase Them Down is in multiple packs, so each of those packs would appear together in an array in "packs_with_options"
+	// and Angel is only in cyclops (as of feb 2023) so that would put 'cyclops' in packs_required
+	var packs_required = []
+	var packs_with_options = []
+	cards.forEach(function(card){
+		if(card.duplicated_by) {
+			packs_with_options.push(
+				[card.pack_code].concat(_.uniq(_.pluck(app.data.cards.find({'code': { '$in': card.duplicated_by}}), 'pack_code')))
+			)
+		} else if(card.duplicate_of_code) {
+			packs_with_options.push(
+				[card.pack_code].concat(_.uniq(_.pluck(app.data.cards.find({'code': { '$in': card.duplicated_of_code}}), 'pack_code')))
+			)
+		} else if(!packs_required.includes(card.pack_code)) {
+			packs_required.push(card.pack_code)
 		}
-		if (card.duplicate_of_code) {
-			var dupe = app.data.cards.findById(card.duplicate_of_code);
-			var req = {};
-			if (!req_hash[dupe.pack_code + card.pack_code]) {
-				var req = req_hash[dupe.pack_code + card.pack_code] = {
-					pack1: {code: dupe.pack_code, name: dupe.pack_name, quantity: Math.max(Math.ceil(card.indeck / dupe.quantity))},
-					pack2: {code: card.pack_code, name: card.pack_name, quantity: Math.max(Math.ceil(card.indeck / card.quantity))}
-				}
-				shared_req.push(req);
+	})
+	var pack_names = _.pluck(
+		app.data.packs.find(
+			{
+				'code': {'$in': packs_required}
+			},
+			{
+				'$orderby': {'available': 1}
 			}
-		} else if (card.duplicated_by && card.duplicated_by.length > 0) {
-			card.duplicated_by.forEach(function(copy) {
-				var dupe = app.data.cards.findById(copy);
-				if (!req_hash[card.pack_code + dupe.pack_code]) {
-					var req = req_hash[card.pack_code + dupe.pack_code] = {
-						pack1: {code: card.pack_code, name: card.pack_name, quantity: Math.max(Math.ceil(card.indeck / card.quantity))},
-						pack2: {code: dupe.pack_code, name: dupe.pack_name, quantity: Math.max(Math.ceil(card.indeck / dupe.quantity))}
+		),
+		'name'
+	)
+	packs_with_options.forEach(function(pack_code_list) {
+		//first, check if one of the options is already in the required list. If it is, we don't need to add this
+		if(_.isEmpty(_.intersection(packs_required, pack_code_list))) {
+			// make a list of all of the possible pack choices, separated by '/'
+			option_string = _.pluck(
+				app.data.packs.find(
+					{
+						'code': {'$in': pack_code_list}
+					},
+					{
+						'$orderby': {'available': 1}
 					}
-					shared_req.push(req);
-				}
-			})
-		} else {
-			if (!req_hash[card.pack_code]) {
-				var req = req_hash[card.pack_code] = Math.max(Math.ceil(card.indeck / card.quantity));
-				requirements.push(req);
-			}
-		}
-	});
-	var pack_codes = _.uniq(_.pluck(cards, 'pack_code'));
-	var packs = app.data.packs.find({}, {
-		'code': {
-			'$in': pack_codes
-		},
-		'$orderBy': {
-			'available': 1
-		}
-	});
-	var new_packs = packs.filter(function (pack) {
-		pack.quantity = req_hash[pack.code] || 0;
-		if (pack.quantity > 0) {
-			return pack
+				),
+				'name'
+			).join(' / ')
+
+			// add it to our master list
+			pack_names.push(option_string)
 		}
 	})
-	// apply additional requirements such as alternative pack pairs
-	shared_req.forEach(function(req) {
-		if (req_hash[req.pack1.code] || req_hash[req.pack2.code]) {
-			// if any pack has another requirement no point showing this option
-			return
-		}
-		new_packs.push({
-			'name': req.pack1.name + ' / ' + req.pack2.name,
-			'quantity': 1
-		})
-	})
-	return new_packs;
+	return pack_names
 }
 
 
@@ -631,8 +619,10 @@ deck.get_layout_data = function get_layout_data(options) {
 	}
 
 	deck.update_layout_section(data, 'meta', $('<div>'+deck.get_draw_deck_size()+' cards </div>').addClass(deck.get_draw_deck_size() < size ? 'text-danger': ''));
-	var pack_string = _.map(deck.get_included_packs(), function (pack) { return pack.name+(pack.quantity > 1 ? ' ('+pack.quantity+')' : ''); }).join(', ');
-	deck.update_layout_section(data, 'meta', $('<div><span onclick="$(\'#packs_required\').toggle()" style="border-bottom: 1px dashed #cfcfcf;" title="' + pack_string + '">' + deck.get_included_packs().length + ' packs required </span>' + ' <div style="display:none;" id="packs_required">'+pack_string+'</div> </div>'));
+	var packs = deck.get_included_packs();
+	var pack_string = packs.join(', ');
+	var pack_count = packs.length
+	deck.update_layout_section(data, 'meta', $('<div><span onclick="$(\'#packs_required\').toggle()" style="border-bottom: 1px dashed #cfcfcf;" title="' + pack_string + '">' + pack_count + ' packs required </span>' + ' <div style="display:none;" id="packs_required">'+pack_string+'</div> </div>'));
 	if(deck.get_tags && deck.get_tags() ) {
 		deck.update_layout_section(data, 'meta', $('<div>'+deck.get_tags().replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();})+'</div>'));
 	}


### PR DESCRIPTION
With this change, one of my wolverine decks went from:

```Captain America, Wasp, Gamora, Mutant Genesis, Cyclops, Wolverine, Storm, Core Set / Valkyrie, Core Set / The Mad Titan's Shadow, Core Set / Gambit, Core Set / Rogue, Core Set / Phoenix, Core Set / Sinister Motives, Core Set / Vision, Core Set / War Machine, Core Set / Nebula, Core Set / Venom, Core Set / Drax, Core Set / Quicksilver, Core Set / Ant-man, Core Set / Hulk, Core Set / Doctor Strange, Core Set / Black Widow, Core Set / Thor, Core Set / Ms. Marvel, Core Set / Scarlet Witch, Core Set / Galaxy's Most Wanted```

to:

```Captain America, Wasp, Gamora, Mutant Genesis, Cyclops, Wolverine, Storm```

much more usable!

Because every hero pack contains energy/strength/genius, you don't end up with them causing a humongous list. Some cards like "Chase them down" have a few options, but it's still a huge improvement.