### PR TITLE
Fix issue 173 - Get server:run to work and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ MarvelsDB
 This guide assumes you know how to use the command-line and that your machine has php and mysql installed.
 
 - install composer: https://getcomposer.org/download/
-- clone the repo somewhere
-- cd to it
+  - NOTE: use version 1.10.26 (the last release of version 1)
+- Git clone the repo and `cd` to it
 - run `composer install` (at the end it will ask for the database configuration parameters)
 - run `php bin/console doctrine:database:create`
 - run `php bin/console doctrine:schema:create`
-- checkout the card data from https://github.com/zzorba/marvelsdb-json-data
-- run `php bin/console app:import:std path-to-marvelsdb-json-data/` pointing to where you checked out the json data
+- Git clone the card data from https://github.com/zzorba/marvelsdb-json-data
+- run `php bin/console app:import:std path-to-marvelsdb-json-data/` pointing to where you cloned the json data (can be a relative path)
 - run `php bin/console server:run`

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ MarvelsDB
 This guide assumes you know how to use the command-line and that your machine has php and mysql installed.
 
 - install composer: https://getcomposer.org/download/
-- Git clone the repo and `cd` to it
+- git clone the repo and `cd` to it
 - run `composer install` (at the end it will ask for the database configuration parameters)
 - if `composer install` fails with version issues, you may need to run `composer self-update --1` to downgrade to composer version 1
 - run `php bin/console doctrine:database:create`
 - run `php bin/console doctrine:schema:create`
-- Git clone the card data from https://github.com/zzorba/marvelsdb-json-data
+- git clone the card data from https://github.com/zzorba/marvelsdb-json-data
 - run `php bin/console app:import:std path-to-marvelsdb-json-data/` pointing to where you cloned the json data (can be a relative path)
 - run `php bin/console server:run`

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -26,7 +26,6 @@ class AppKernel extends Kernel
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Symfony\Bundle\AsseticBundle\AsseticBundle(),
-            new Symfony\Bundle\WebServerBundle\WebServerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new JMS\I18nRoutingBundle\JMSI18nRoutingBundle(),
@@ -39,6 +38,7 @@ class AppKernel extends Kernel
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {
+            $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
             $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -26,6 +26,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Symfony\Bundle\AsseticBundle\AsseticBundle(),
+            new Symfony\Bundle\WebServerBundle\WebServerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new JMS\I18nRoutingBundle\JMSI18nRoutingBundle(),


### PR DESCRIPTION
This PR addresses issue https://github.com/zzorba/marvelsdb/issues/173. The `server:run` command wouldn't work until I added an additional Symfony bundle. I found a similar issue mentioned in the arkhamdb repo, which this repo is cloned from.

I also updated the README to clarify that composer 1.10 is needed for this to run since the code doesn't work with composer 2+ yet.

With these changes, I'm able to run `php bin/console server:run` and successfully load the website running at http://127.0.0.1:8000.