### PR TITLE
Allow nullable villain stage number

### DIFF
--- a/src/AppBundle/Resources/public/js/app.tip.js
+++ b/src/AppBundle/Resources/public/js/app.tip.js
@@ -9,7 +9,7 @@ function getCardText(card) {
 	var content = image
 	+ '<h4 class="card-name">' + app.format.name(card) + '</h4>'
 	+ '<div class="card-faction">' + app.format.faction(card) + '</div>'
-	+ '<div><span class="card-type">'+card.type_name+((card.type_code == "main_scheme" || card.type_code == 'villain') ? '. Stage '+card.stage : '')+(card.subtype_name ? '. '+card.subtype_name : "")+'</span></div>'
+	+ '<div><span class="card-type">' + card.type_name + (card.stage && (card.type_code == "main_scheme" || card.type_code == 'villain') ? '. Stage ' + card.stage : '') + (card.subtype_name ? '. ' + card.subtype_name : "") + '</span></div>'
 	+ '<div class="card-traits">' + app.format.traits(card) + '</div>'
 	;
 

--- a/src/AppBundle/Resources/views/Search/card-stage.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-stage.html.twig
@@ -1,4 +1,4 @@
-{% if card.type_code == 'villain' %}
+{% if card.type_code == 'villain' and card.stage %}
  {% if card.stage == 1 %}(I){% elseif card.stage == 2 %}(II){% elseif card.stage == 3 %}(III){% elseif card.stage == 4 %}(IV){% elseif card.stage == 5 %}(V){% else %}({{ card.stage }}){% endif %}
 {% elseif card.type_code == 'main_scheme' %}
   - {{ card.stage }}{% if is_back %}A{% else %}B{% endif %}


### PR DESCRIPTION
This should fix a villains that don't have the traditional I, II, or III stage numbers associated with them and are instead double sided with just A or B sides and a null stage.

Magog https://marvelcdb.com/card/39001a
Avalanche https://marvelcdb.com/card/32121a
Blob https://marvelcdb.com/card/32122a
Pyro https://marvelcdb.com/card/32123a
Toad https://marvelcdb.com/card/32124a