### PR TITLE
Include meta property for hero cards as part of the import std command

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -615,6 +615,12 @@ class ImportStdCommand extends ContainerAwareCommand
 			}
 		}
 
+		if ($key == "meta"){
+			if ($value){
+				$value = json_encode($value);
+			}
+		}
+
 		if ($key == "deck_options" && $value){
 			if ($value){
 				$value = json_encode($value);
@@ -759,6 +765,7 @@ class ImportStdCommand extends ContainerAwareCommand
 			'attack',
 			'defense',
 			'thwart',
+			'meta'
 		];
 		foreach($mandatoryKeys as $key) {
 			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, TRUE);


### PR DESCRIPTION
I've been running the `app:import:std` command to get the JSON data into the database to test JSON changes and to test new features. After I would log in to my local running instance of marvelsdb, I ran into an error in `macros.html.twig`  on line 56 when it tried to access the Hero meta colors. Cannot access `colors` off of null object.

```
<div style="display: flex; flex-direction: column; background-image: linear-gradient(100deg, {{hero_meta.colors[0]}} 49.5%, {{hero_meta.colors[2]}} 50%, {{hero_meta.colors[2]}} 51%, {{hero_meta.colors[1]}} 51.5%, {{hero_meta.colors[1]}} 100%); border-radius: 5px; padding: 0.5rem;">
```

The `meta` column in the database was completely null for every card. Looks like the `app:import:std` command wasn't looking at that property in the JSON so it was never imported.

Once I fixed this and re-ran the `app:import:std` command, the database `meta` column was populated for the hero cards, the bug went away, and the hero colors showed up.

I made this a mandatoryKey for the hero card because it seems like it should be defined for every hero card, especially if there's code that expects it to be set for hero cards. The weird thing about this is that heroes with multiple hero cards (e.g. Ant-Man, Ironheart, Wasp) will need to define the colors on each of their hero cards in their deck. I'll create a related PR in the marvelsdb-json-data repo to fix this for those three heroes if this is the right direction. If this should be an optionalKey instead, I'll change it to that but I think it might be useful to explain why so that I can understand the reasoning behind mandatory/optional.