### PR TITLE
Add initial support for Player Side Schemes

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -723,6 +723,9 @@ class ImportStdCommand extends ContainerAwareCommand
 			if ($cleanName == "Main Scheme") {
 				$cleanName = "MainScheme";
 			}
+			if ($cleanName == "Player Side Scheme") {
+				$cleanName = "PlayerSideScheme";
+			}
 			$functionName = 'import' . $cleanName . 'Data';
 			$this->$functionName($entity, $data);
 		}
@@ -865,6 +868,24 @@ class ImportStdCommand extends ContainerAwareCommand
 				'scheme_acceleration',
 				'scheme_crisis',
 				'scheme_hazard',
+		];
+
+		foreach($mandatoryKeys as $key) {
+			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, TRUE);
+		}
+
+		foreach($optionalKeys as $key) {
+			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, FALSE);
+		}
+	}
+
+	protected function importPlayerSideSchemeData(Card $card, $data)
+	{
+		$mandatoryKeys = [
+			'base_threat',
+		];
+		$optionalKeys = [
+			'base_threat_fixed'
 		];
 
 		foreach($mandatoryKeys as $key) {

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -68,6 +68,14 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 				$optionalFields[] = 'resource_mental';
 				$optionalFields[] = 'resource_wild';
 				break;
+			case 'player_side_scheme':
+				$mandatoryFields[] = 'cost';
+				$mandatoryFields[] = 'base_threat';
+				$optionalFields[] = 'base_threat_fixed';
+				$optionalFields[] = 'resource_energy';
+				$optionalFields[] = 'resource_physical';
+				$optionalFields[] = 'resource_mental';
+				$optionalFields[] = 'resource_wild';
 			case 'ally':
 				$mandatoryFields[] = 'cost';
 				$optionalFields[] = 'thwart';

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -42,8 +42,8 @@ var date_creation,
  */
 // one column view
 layouts[1] = _.template('<div class="deck-block" style="background-image: linear-gradient(100deg, <%= hero_color_1 %> 49.5%, <%= hero_color_3 %> 50%, <%= hero_color_3 %> 51%, <%= hero_color_2 %> 51.5%, <%= hero_color_2 %> 100%);"><div class="deck-header"><div class="deck-meta"><%= meta %></div><div class="deck-hero-image"><%= image1 %><%= image2 %></div></div><div class="deck-content"><div class="col-sm-10 col-print-10"><%= cards %></div><div></div></div></div>');
-// two colunm view (default for most)
-layouts[2] = _.template('<div class="deck-block" style="background-image: linear-gradient(100deg, <%= hero_color_1 %> 49.5%, <%= hero_color_3 %> 50%, <%= hero_color_3 %> 51%, <%= hero_color_2 %> 51.5%, <%= hero_color_2 %> 100%);"><div class="deck-header"><div class="deck-meta"><%= meta %></div><div class="deck-hero-image"><%= image1 %><%= image2 %></div></div><div class="deck-content"><div><%= allies %><%= events %><%= resources %></div><div><%= supports %><%= upgrades %> <%= permanent %></div></div></div>');
+// two column view (default for most)
+layouts[2] = _.template('<div class="deck-block" style="background-image: linear-gradient(100deg, <%= hero_color_1 %> 49.5%, <%= hero_color_3 %> 50%, <%= hero_color_3 %> 51%, <%= hero_color_2 %> 51.5%, <%= hero_color_2 %> 100%);"><div class="deck-header"><div class="deck-meta"><%= meta %></div><div class="deck-hero-image"><%= image1 %><%= image2 %></div></div><div class="deck-content"><div><%= allies %><%= events %><%= player_side_schemes %><%= resources %></div><div><%= supports %><%= upgrades %> <%= permanent %></div></div></div>');
 
 /**
  * @memberOf deck
@@ -564,6 +564,7 @@ deck.get_layout_data = function get_layout_data(options) {
 			events: '',
 			allies: '',
 			permanent: '',
+			player_side_schemes: '',
 			supports: '',
 			resources: '',
 			cards: '',
@@ -694,6 +695,7 @@ deck.get_layout_data = function get_layout_data(options) {
 		deck.update_layout_section(data, 'resources', deck.get_layout_data_one_section({'type_code': 'resource'}, 'type_name'));
 		deck.update_layout_section(data, 'allies', deck.get_layout_data_one_section({'type_code': 'ally'}, 'type_name'));
 		deck.update_layout_section(data, 'supports', deck.get_layout_data_one_section({'type_code': 'support', permanent: false}, 'type_name'));
+		deck.update_layout_section(data, 'player_side_schemes', deck.get_layout_data_one_section({'type_code': 'player_side_scheme', permanent: false}, 'type_name'));
 
 		deck.update_layout_section(data, 'permanent', deck.get_layout_data_one_section({permanent: true}, 'type_name'));
 	}

--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -154,8 +154,12 @@ format.info = function info(card) {
 		case 'upgrade':
 		case 'resource':
 		case 'event':
+		case 'player_side_scheme':
 			if (card.type_code != 'resource') {
 				text += '<div>Cost: '+format.fancy_int(card.cost)+'. '+'</div>';
+			}
+			if (card.type_code == 'player_side_scheme') {
+				text += '<div>Threat: '+format.fancy_int(card.base_threat)+(!card.base_threat_fixed?'<span class="icon icon-per_hero"></span>':'') + '.';
 			}
 			if (card.resource_physical || card.resource_mental || card.resource_energy || card.resource_wild){
 				text += '<div>Resource: ';

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -131,13 +131,18 @@ ui.build_faction_selector = function build_faction_selector() {
  */
 ui.build_type_selector = function build_type_selector() {
 	$('[data-filter=type_code]').empty();
-	['upgrade','support','event', 'ally', 'resource'].forEach(function(type_code) {
+	['ally', 'event', 'player_side_scheme', 'resource', 'support', 'upgrade'].forEach(function(type_code) {
 		var example = app.data.cards.find({"type_code": type_code})[0];
 		// not all card types might exist
 		if (example) {
+			var displayedTypeName = example.type_name;
+			if (type_code == 'player_side_scheme') {
+				// Player Side Scheme is too long to fit in the button without overflowing
+				displayedTypeName = 'Side Scheme';
+			}
 			var label = $('<label class="btn btn-default btn-sm" data-code="'
 					+ type_code + '" title="'+example.type_name+'"><input type="checkbox" name="' + type_code
-					+ '"><span class="icon-' + type_code + '"></span>' + example.type_name + '</label>');
+					+ '"><span class="icon-' + type_code + '"></span>' + displayedTypeName + '</label>');
 			label.tooltip({container: 'body'});
 			$('[data-filter=type_code]').append(label);
 		}

--- a/src/AppBundle/Resources/views/Search/card-props.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-props.html.twig
@@ -17,7 +17,15 @@
 	</div>
 	{% endif %}
 </div>
+{% endif %}
 
+{% if card.type_code == 'player_side_scheme' %}
+<div class="card-props">
+  {% trans %}Cost{% endtrans %}: {{ macros.integer_or_x(card.cost) }}.
+	<div>
+		{% trans %}Threat{% endtrans %}: {{ macros.integer_or_x(card.base_threat) }}{% if not card.base_threat_fixed %}<span class="icon icon-per_hero"></span>{% endif %}.
+	</div>
+</div>
 {% endif %}
 
 {% if card.type_code == 'hero' or card.type_code == 'alter_ego' %}


### PR DESCRIPTION
I'm adding initial support for Player Side Schemes, which is a new card type being introduced in the NeXt Evolution campaign expansion. They are similar to Side Schemes but players can add them to their hero packs and they result in positive outcomes when cleared.

In the deck view, this new Player Side Scheme type appears alphabetically on the left column under Ally and Event and above Resource.
<img width="566" alt="Screen Shot 2023-04-16 at 2 24 33 PM" src="https://user-images.githubusercontent.com/8204905/232343274-473027fb-8d80-4a2e-af16-844c9dcd752b.png">

In the build view, I rearranged the card type buttons to also be alphabetical. This will better match the order of the types of cards when they appear in the deck and I think this also makes things easier if new card types continue to get added (although all unique card types in a row probably won't scale well if there are too many more new cards introduced).

<img width="583" alt="Screen Shot 2023-04-16 at 2 25 52 PM" src="https://user-images.githubusercontent.com/8204905/232343442-3ef6af3a-c62b-4fda-900b-4fa9d00b0c2d.png">


**NOTE**
I am labeling the button as just "Side Scheme" and not "Player Side Scheme" (although the flyout is the full "Player Side Scheme") because the full text overflows into the "Resource" button. This might be a little confusing but given the current layout, I'm not sure how else to handle this without potentially coming up with an abbreviation (like PSS) that I'm not sure all players will understand.


For testing, I've been working with a local branch of the marvelsdb-json-data that contains the announced NeXt Evolution cards so I've been able to verify the flyouts for these new Player Side Scheme cards display the proper information.