### PR TITLE
Import scheme_hazard for upgrade and ally cards

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -748,7 +748,12 @@ class ImportStdCommand extends ContainerAwareCommand
 
 	protected function importUpgradeData(Card $card, $data)
 	{
-
+		$optionalKeys = [
+			'scheme_hazard',
+		];
+		foreach($optionalKeys as $key) {
+			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, FALSE);
+		}
 	}
 
 	protected function importObligationData(Card $card, $data)
@@ -797,6 +802,7 @@ class ImportStdCommand extends ContainerAwareCommand
 		$optionalKeys = [
 			'attack_cost',
 			'thwart_cost',
+			'scheme_hazard',
 		];
 		foreach($mandatoryKeys as $key) {
 			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, TRUE);


### PR DESCRIPTION
There are two cards in the Sinister Motives box that use `scheme_hazard` but it wasn't getting imported into the database correctly. This change includes those optional fields for ally and upgrade card types in the import step.

https://marvelcdb.com/card/27190

https://marvelcdb.com/card/27191

This should also fix https://github.com/zzorba/marvelsdb/issues/186.