### PR TITLE
Add support for the new 'Pool faction

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -895,7 +895,10 @@ class ImportStdCommand extends ContainerAwareCommand
 			'base_threat',
 		];
 		$optionalKeys = [
-			'base_threat_fixed'
+			'base_threat_fixed',
+			'scheme_acceleration',
+			'scheme_crisis',
+			'scheme_hazard',
 		];
 
 		foreach($mandatoryKeys as $key) {

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -471,7 +471,7 @@ class BuilderController extends Controller
 			try {
 				$meta_json = json_decode($meta);
 				if ($meta_json && isset($meta_json->aspect)) {
-					if ($meta_json->aspect == "leadership" || $meta_json->aspect == "protection" || $meta_json->aspect == "justice" || $meta_json->aspect == "aggression") {
+					if ($meta_json->aspect == "leadership" || $meta_json->aspect == "protection" || $meta_json->aspect == "justice" || $meta_json->aspect == "aggression" || $meta_json->aspect == "pool") {
 
 					} else {
 						return false;
@@ -741,7 +741,7 @@ class BuilderController extends Controller
 			f.name,
 			f.code
 			from faction f
-			where f.code IN ('justice', 'aggression', 'leadership', 'protection')
+			where f.code IN ('justice', 'aggression', 'leadership', 'protection', 'pool')
 			order by f.name asc")
 			->fetchAll();
 

--- a/src/AppBundle/Controller/Oauth2Controller.php
+++ b/src/AppBundle/Controller/Oauth2Controller.php
@@ -300,7 +300,7 @@ class Oauth2Controller extends Controller
 			try {
 				$meta_json = json_decode($meta);
 				if ($meta_json && isset($meta_json->aspect)) {
-					if ($meta_json->aspect == "leadership" || $meta_json->aspect == "protection" || $meta_json->aspect == "justice" || $meta_json->aspect == "aggression") {
+					if ($meta_json->aspect == "leadership" || $meta_json->aspect == "protection" || $meta_json->aspect == "justice" || $meta_json->aspect == "aggression" || $meta_json->aspect == "pool") {
 						
 					} else {
 						return false;

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -393,7 +393,7 @@ class SocialController extends Controller
 			f.name,
 			f.code
 			from faction f
-			where f.code IN ('justice', 'aggression', 'leadership', 'protection')
+			where f.code IN ('justice', 'aggression', 'leadership', 'protection', 'pool')
 			order by f.name asc")
 			->fetchAll();
 		$params['faction_selected'] = $faction_code;
@@ -465,7 +465,7 @@ class SocialController extends Controller
 			f.name,
 			f.code
 			from faction f
-			where f.code IN ('justice', 'aggression', 'leadership', 'protection')
+			where f.code IN ('justice', 'aggression', 'leadership', 'protection', 'pool')
 			order by f.name asc")
 			->fetchAll();
 
@@ -619,7 +619,7 @@ class SocialController extends Controller
 		f.name,
 		f.code
 		from faction f
-		where f.code IN ('justice', 'aggression', 'leadership', 'protection')
+		where f.code IN ('justice', 'aggression', 'leadership', 'protection', 'pool')
 		order by f.name asc")
 		->fetchAll();
 

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -76,6 +76,9 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 				$optionalFields[] = 'resource_physical';
 				$optionalFields[] = 'resource_mental';
 				$optionalFields[] = 'resource_wild';
+				$optionalFields[] = 'scheme_acceleration';
+				$optionalFields[] = 'scheme_crisis';
+				$optionalFields[] = 'scheme_hazard';
 			case 'ally':
 				$mandatoryFields[] = 'cost';
 				$optionalFields[] = 'thwart';

--- a/src/AppBundle/Resources/public/css/style.css
+++ b/src/AppBundle/Resources/public/css/style.css
@@ -776,6 +776,10 @@ div.site-slogan {
 	background-color: #ead51b !important;
 	color: black !important;
 }
+.bg-pool {
+	background-color: #d074ac !important;
+	color: white !important;
+}
 
 
 .faint-faction a, .faint-faction span {
@@ -796,6 +800,9 @@ div.site-slogan {
 .faint-justice {
 	background-color: rgba(228, 228, 0, 0.2) !important;
 }
+.faint-pool {
+	background-color: rgba(212, 126, 178, 0.2) !important;
+}
 
 .fg-leadership {
 	color: #3499eb !important;
@@ -811,6 +818,9 @@ div.site-slogan {
 }
 .fg-justice {
 	color: #f2ca00 !important;
+}
+.fg-pool {
+	color: #d47eb2 !important;
 }
 
 .border-leadership {
@@ -828,6 +838,9 @@ div.site-slogan {
 .border-justice {
 	border-color: #c0c000 !important;
 	border-color: #f5de11 !important;
+}
+.border-pool {
+	border-color: #d074ac !important;
 }
 
 .icon-guardian, .icon-mystic, .icon-seeker, .icon-rogue, .icon-survivor {

--- a/src/AppBundle/Resources/public/js/app.deck_charts.js
+++ b/src/AppBundle/Resources/public/js/app.deck_charts.js
@@ -6,29 +6,15 @@
 		}
 	});
 
-
-	var charts = [],
-		faction_colors = {
-	
-			leadership:
-				'#2b80c5',
-	
-			aggression :
-				'#cc3038',
-	
-			protection :
-				'#107116',
-	
-			basic :
-				'#808080',
-	
-			justice :
-				'#c0c000',
-	
-			hero :
-				'#AB006A'
-	
-		};
+	var faction_colors = {
+		leadership: '#2b80c5',
+		aggression: '#cc3038',
+		protection: '#107116',
+		basic: '#808080',
+		justice: '#c0c000',
+		pool: '#d074ac',
+		hero: '#AB006A'
+	};
 
 deck_charts.chart_faction = function chart_faction() {
 	var factions = {};

--- a/src/AppBundle/Resources/views/Builder/tab-pane-build.html.twig
+++ b/src/AppBundle/Resources/views/Builder/tab-pane-build.html.twig
@@ -16,6 +16,7 @@
 				<li><a href="#" onclick="app.deck.change_aspect('protection')" id="btn-sort-name"><span class="fa fa-circle fg-protection"></span> Protection</span></a></li>
 				<li><a href="#" onclick="app.deck.change_aspect('justice')" id="btn-sort-position"><span class="fa fa-circle fg-justice"></span> Justice</a></li>
 				<li><a href="#" onclick="app.deck.change_aspect('aggression')" id="btn-sort-position"><span class="fa fa-circle fg-aggression"></span> Aggression</a></li>
+				<li><a href="#" onclick="app.deck.change_aspect('pool')" id="btn-sort-position"><span class="fa fa-circle fg-pool"></span> 'Pool</a></li>
 			</ul>
 		</div>
 
@@ -28,6 +29,7 @@
 				<li><a href="#" onclick="app.deck.change_aspect2('protection')" id="btn-sort-name"><span class="fa fa-circle fg-protection"></span> Protection</span></a></li>
 				<li><a href="#" onclick="app.deck.change_aspect2('justice')" id="btn-sort-position"><span class="fa fa-circle fg-justice"></span> Justice</a></li>
 				<li><a href="#" onclick="app.deck.change_aspect2('aggression')" id="btn-sort-position"><span class="fa fa-circle fg-aggression"></span> Aggression</a></li>
+				<li><a href="#" onclick="app.deck.change_aspect2('pool')" id="btn-sort-position"><span class="fa fa-circle fg-pool"></span> 'Pool</a></li>
 			</ul>
 		</div>
 


### PR DESCRIPTION
Add support for the new 'Pool faction that is added in the Deadpool hero pack.

This is related to https://github.com/zzorba/marvelsdb-json-data/pull/433 and should probably get merged around the same time.

I grabbed the pink colors from the new 'Pool cards so it should be fairly accurate. I also added support for Player Side Schemes to use `scheme_acceleration`, `scheme_crisis`, and `scheme_hazard` which is part of the Deadpool hero pack.