### PR TITLE
Remove main-scheme inversion

### DIFF
--- a/src/AppBundle/Resources/views/Search/card-backname-with-link.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-backname-with-link.html.twig
@@ -1,4 +1,4 @@
 {% if card.is_unique == true %}<span class="icon-unique"></span> {% endif %}
-<a href="{{ card.url }}" class="card-name card-tip{% if card.available == false %} card-preview{% endif %}{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %}" data-code="{{ card.code }}">{% if card.back_name %}{{ card.back_name }}{% else %}{{ card.name }}{% endif %}{% include 'AppBundle:Search:card-stage.html.twig' with { 'is_back': true } %}
+<a href="{{ card.url }}" class="card-name card-tip{% if card.available == false %} card-preview{% endif %}{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %}" data-code="{{ card.code }}">{% if card.back_name %}{{ card.back_name }}{% else %}{{ card.name }}{% endif %}{% include 'AppBundle:Search:card-stage.html.twig' %}
 </a>
 {% if card.subname %}<div class="card-subname small{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %}">{{ card.subname }}</div>{% endif %}

--- a/src/AppBundle/Resources/views/Search/card-name-with-link.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-name-with-link.html.twig
@@ -1,4 +1,4 @@
 {% if card.is_unique == true %}<span class="icon-unique"></span> {% endif %}
-<a href="{{ card.url }}" class="card-name card-tip{% if card.available == false %} card-preview{% endif %}{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %}" data-code="{{ card.code }}">{{ card.name }}{% include 'AppBundle:Search:card-stage.html.twig' with { 'is_back': false } %}
+<a href="{{ card.url }}" class="card-name card-tip{% if card.available == false %} card-preview{% endif %}{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %}" data-code="{{ card.code }}">{{ card.name }}{% include 'AppBundle:Search:card-stage.html.twig' %}
 </a>
 {% if card.subname %}<div class="card-subname small{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %}">{{ card.subname }}</div> {% endif %}

--- a/src/AppBundle/Resources/views/Search/card-props.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-props.html.twig
@@ -54,14 +54,21 @@
 	{% if (card.scheme is defined and card.scheme != 0) or (card.scheme_star) %}
 	  <div>{% trans %}Scheme{% endtrans %}: {% if card.scheme > 0 %}+{% endif %}{{ macros.format_integer(card.scheme, card.scheme_star) }}</div>
 	{% endif %}
-{% elseif card.type_code == 'side_scheme' or card.type_code == 'main_scheme' %}
+{% elseif card.type_code == 'side_scheme' %}
 	<div>
 	{% trans %}Starting Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, null, not card.base_threat_fixed) }}.
 	{% if card.escalation_threat %}
 		{% trans %}Escalation Threat{% endtrans %}: {{ macros.format_integer(card.escalation_threat, card.escalation_threat_star, not card.escalation_threat_fixed) }}.
 	{% endif %}
 	</div>
-	{% if card.type_code == 'main_scheme' %}
+{% elseif card.type_code == 'main_scheme' %}
+	{% if card.linked_card is not defined %}
+	<div>
+	{% trans %}Starting Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, null, not card.base_threat_fixed) }}.
+	{% if card.escalation_threat %}
+		{% trans %}Escalation Threat{% endtrans %}: {{ macros.format_integer(card.escalation_threat, card.escalation_threat_star, not card.escalation_threat_fixed) }}.
+	{% endif %}
+	</div>
   	{% trans %}Threat{% endtrans %}: {{ macros.format_integer(card.threat, card.threat_star, not card.threat_fixed) }}.
 	{% endif %}
 {% else %}

--- a/src/AppBundle/Resources/views/Search/card-stage.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-stage.html.twig
@@ -1,5 +1,5 @@
 {% if card.type_code == 'villain' and card.stage %}
  {% if card.stage == 1 %}(I){% elseif card.stage == 2 %}(II){% elseif card.stage == 3 %}(III){% elseif card.stage == 4 %}(IV){% elseif card.stage == 5 %}(V){% else %}({{ card.stage }}){% endif %}
 {% elseif card.type_code == 'main_scheme' %}
-  - {{ card.stage }}{% if is_back %}A{% else %}B{% endif %}
+  - {{ card.stage }}{% if card.linked_card is defined %}A{% else %}B{% endif %}
 {% endif %}

--- a/src/AppBundle/Resources/views/Search/display-card.html.twig
+++ b/src/AppBundle/Resources/views/Search/display-card.html.twig
@@ -15,13 +15,8 @@
     <div class="col-md-9">
         <div class="row">
 				{% for card in cards %}
-        	{% if card.type_code == "main_scheme" %}
-        	{% include 'AppBundle:Search:card-back.html.twig' %}
-        	{% include 'AppBundle:Search:card-front.html.twig' %}
-        	{% else %}
         	{% include 'AppBundle:Search:card-front.html.twig' %}
         	{% include 'AppBundle:Search:card-back.html.twig' %}
-        	{% endif %}
 	        {% if includeReviews %}
 	        	{% include 'AppBundle:Search:display-card-related.html.twig' %}
 	   	    	{% include 'AppBundle:Search:display-card-reviews.html.twig' %}

--- a/src/AppBundle/Resources/views/Search/display-list.html.twig
+++ b/src/AppBundle/Resources/views/Search/display-list.html.twig
@@ -21,7 +21,7 @@
 	<td data-th="Name">
 		<span class="icon icon-{{ card.type_code}} fg-{{ card.faction_code }}"></span>
 		<a href="{{ card.url }}" class="{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %} card-tip{% if card.available == false %} card-preview{% endif %}" data-code="{{ card.code }}">
-		{{ card.name }}{% if card.type_code == 'villain' %}{% include 'AppBundle:Search:card-stage.html.twig' with { 'is_back': false } %}{% endif %}{% if card.subname%}: {{ card.subname }}{% endif %}</a>
+		{{ card.name }}{% if card.type_code == 'villain' %}{% include 'AppBundle:Search:card-stage.html.twig' %}{% endif %}{% if card.subname%}: {{ card.subname }}{% endif %}</a>
 	</td>
 	<td data-th="Faction" style="width : 100px;" class="fg-{{ card.faction_code }}"><span class="icon-{{card.faction_code}}"></span>{% if card.faction2_code is defined %}<span class="icon-{{card.faction2_code}}"></span> {% else %} {{ card.faction_name }} {% endif %}  </td>
 	<td data-th="Cost" style="width : 30px;">{{ card.cost }}</td>


### PR DESCRIPTION
This dev will fix main scheme display
see https://github.com/zzorba/marvelsdb-json-data/issues/549 for details

This dev should be merged at the same time as https://github.com/zzorba/marvelsdb-json-data/pull/551 (use back_link method on all main schemes)

Tested in local environment, here is some snapshot of the result:
[Terrestrial Invasion - 1A](https://marvelcdb.com/card/16061a)
![image](https://github.com/user-attachments/assets/e151148f-4e78-4b8c-96b1-4deb9db9b16f)

[Hunting Gene Traitors - 1A](https://marvelcdb.com/card/45062)
![image](https://github.com/user-attachments/assets/add1eee0-6c86-4aed-a596-f06848191a9a)

[Underground Distribution - 1A](https://marvelcdb.com/card/01116)
![image](https://github.com/user-attachments/assets/6ecf79ab-d2d3-46d6-98fe-713ba0c0ca33)




