### PR TITLE
extend crisis icon support for upgrades

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -746,6 +746,7 @@ class ImportStdCommand extends ContainerAwareCommand
 	protected function importUpgradeData(Card $card, $data)
 	{
 		$optionalKeys = [
+			'scheme_crisis',
 			'scheme_hazard',
 		];
 		foreach($optionalKeys as $key) {


### PR DESCRIPTION

upgrades does not currently support crisis icon
[Distraction](https://marvelcdb.com/card/44054)

![image](https://github.com/user-attachments/assets/1dba23d7-3e8a-4066-a605-24c90d1181d0)
