### PR TITLE
support boost and star icon for environment cards

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -859,6 +859,8 @@ class ImportStdCommand extends ContainerAwareCommand
 	protected function importEnvironmentData(Card $card, $data)
 	{
 		$optionalKeys = [
+			'boost',
+			'boost_star',
 			'scheme_acceleration',
 			'scheme_hazard',
 		];


### PR DESCRIPTION

Currently boost icon and boost star are not displayed for environment cards

[Genosha](https://marvelcdb.com/card/45133)

![image](https://github.com/user-attachments/assets/f6497137-1640-4a04-a099-6afe5fc71c58)

this dev fix this (following screen comes from dev environment):

![image](https://github.com/user-attachments/assets/1f1f874f-efef-4278-bf03-7250e0503507)

