### PR TITLE
Remove campaign button on edit deck page

### DIFF
--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -109,7 +109,7 @@ ui.build_faction_selector = function build_faction_selector() {
 	faction_codes.push('basic');
 
 	faction_codes.forEach(function(faction_code) {
-		if (faction_code == "hero" || faction_code == "encounter"){
+		if (faction_code == "hero" || faction_code == "encounter" || faction_code == "campaign"){
 			return;
 		}
 		var example = app.data.cards.find({"faction_code": faction_code})[0];


### PR DESCRIPTION

Currently on the edit deck page, there is a filter button "campaign"
I don't think it is a desired feature to create decks with campaign cards

![image](https://github.com/user-attachments/assets/03a73090-8079-425e-888f-ef3172fea73c)

This dev removes the campaign button

devenv screenshot:
![image](https://github.com/user-attachments/assets/f76d11dd-d7b6-4b63-bc54-595cb74863ae)
