### PR TITLE
update Adam warlock logic to support pool aspect - NOTE: COULD NOT TEST

### DIFF
--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -999,7 +999,7 @@ deck.get_problem = function get_problem() {
 		// Adam Warlock deck requirements
 		// Adam is required to have an equal number of cards in 4 aspects. Since the new pool aspect
 		// was added, we need to check the counts of all 5 aspects, and check that 4 of them are equal,
-		// and one of them is zero
+		// and one of them is zero. We also check for if there are 0 cards in any aspect, which is legal.
 		if (deck.requirements.aspects && deck.requirements.aspects == 4) {
 			var counts = [
 				deck.get_aspect_count('leadership'),
@@ -1019,12 +1019,15 @@ deck.get_problem = function get_problem() {
 				if (num === 0 && count === 1) {
 					hasOneZero = true;
 				}
+				if (num === 0 && count === 5) {
+					hasFiveZero = true;
+				}
 				if (count === 4) {
 					hasFourEqual = true;
 				}
 			}
-			isAspectCountCorrect = hasFourEqual && hasOneZero;
-			}
+
+			isAspectCountCorrect = (hasFourEqual && hasOneZero) || hasFiveZero;
 			if (!isAspectCountCorrect) {
 				return "investigator";
 			}

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -996,17 +996,36 @@ deck.get_problem = function get_problem() {
 	}
 
 	if (deck.requirements) {
+		// Adam Warlock deck requirements
+		// Adam is required to have an equal number of cards in 4 aspects. Since the new pool aspect
+		// was added, we need to check the counts of all 5 aspects, and check that 4 of them are equal,
+		// and one of them is zero
 		if (deck.requirements.aspects && deck.requirements.aspects == 4) {
 			var counts = [
 				deck.get_aspect_count('leadership'),
 				deck.get_aspect_count('aggression'),
 				deck.get_aspect_count('protection'),
-				deck.get_aspect_count('justice')
+				deck.get_aspect_count('justice'),
+				deck.get_aspect_count('pool')
 			]
-			if (!counts.every(function(val){
-				console.log(val)
-				return val == counts[0];
-			})) {
+			// Create a map to count occurrences of each aspect count
+			const countMap = new Map();
+			for (let num of counts) {
+				countMap.set(num, (countMap.get(num) || 0) + 1);
+			}
+			let hasFourEqual = false;
+			let hasOneZero = false;
+			for (let [num, count] of countMap) {
+				if (num === 0 && count === 1) {
+					hasOneZero = true;
+				}
+				if (count === 4) {
+					hasFourEqual = true;
+				}
+			}
+			isAspectCountCorrect = hasFourEqual && hasOneZero;
+			}
+			if (!isAspectCountCorrect) {
 				return "investigator";
 			}
 		} else if (deck.requirements.aspects) {

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -1015,6 +1015,7 @@ deck.get_problem = function get_problem() {
 			}
 			let hasFourEqual = false;
 			let hasOneZero = false;
+			let hasFiveZero = false;
 			for (let [num, count] of countMap) {
 				if (num === 0 && count === 1) {
 					hasOneZero = true;


### PR DESCRIPTION
This is a small update to make the logic that checks if a deck is valid support the 'Pool aspect in adam warlock.

I struggled to get my local PHP version correct so I could run the code, and was not able to. So I could not test this code. It *should* work, but I recommended doing a quick local test before deploying. Apologies I could not test it myself!