### PR TITLE
Search class filter unchecked by default

### DIFF
--- a/src/AppBundle/Resources/views/Search/searchform.html.twig
+++ b/src/AppBundle/Resources/views/Search/searchform.html.twig
@@ -55,8 +55,8 @@
 				<div class="form-group">
 			<div class="btn-group" data-toggle="buttons">
 			{% for faction in factions %}
-				<label class="btn btn-default active" title="{{ faction.name }}" data-toggle="tooltip" data-container="body">
-					<input type="checkbox" name="f[]" checked value="{{ faction.code }}">
+				<label class="btn btn-default" title="{{ faction.name }}" data-toggle="tooltip" data-container="body">
+					<input type="checkbox" name="f[]" value="{{ faction.code }}">
 					<span class="icon icon-{{ faction.code }}"></span>{{ faction.name }}
 				</label>
 			{% endfor %}


### PR DESCRIPTION
fix https://github.com/zzorba/marvelsdb/issues/277

tested in local dev environment, works fine, all aspect button are unchecked by default:

![image](https://github.com/user-attachments/assets/080bbc62-99c4-4ea1-a615-b2fad1434749)
