### PR TITLE
Set type filter on ally by default

### DIFF
--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -263,6 +263,7 @@ ui.init_selectors = function init_selectors() {
 		$('[data-filter=faction_selector]').val(app.deck.meta.faction_selected);
 	}
 
+	$('[data-filter=type_code]').find('input[name=ally]').prop("checked", true).parent().addClass('active');
 }
 
 function uncheck_all_others() {


### PR DESCRIPTION

fix https://github.com/zzorba/marvelsdb/issues/283

This dev set a value by default for the type filter

I chose arbitrarily the "ally" as default value