### PR TITLE
Support new erratum property

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -491,6 +491,7 @@ class ImportStdCommand extends ContainerAwareCommand
 				'is_unique',
 				'hidden',
 				'permanent',
+				'erratum',
 				'octgn_id'
 
 			]);

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -23,6 +23,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 
 		$optionalFields = [
 			'illustrator',
+			'erratum',
 			'flavor',
 			'traits',
 			'text',
@@ -492,6 +493,11 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	 * @var \AppBundle\Entity\Card
 	 */
 	private $linked_to;
+
+	/**
+	 * @var string
+	 */
+	private $erratum;
 
 	/**
 	 * Constructor
@@ -2636,5 +2642,28 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
     public function getSchemeHazard()
     {
         return $this->schemeHazard;
+    }
+
+    /**
+     * Set erratum
+     *
+     * @param string $erratum
+     *
+     * @return Card
+     */
+    public function setErratum($erratum)
+    {
+        $this->erratum = $erratum;
+        return $this;
+    }
+
+    /**
+     * Get erratum
+     *
+     * @return string
+     */
+    public function getErratum()
+    {
+        return $this->erratum;
     }
 }

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -320,6 +320,9 @@ AppBundle\Entity\Card:
             type: boolean
             nullable: true
             column: escalation_threat_star
+        erratum:
+            type: text
+            nullable: true
     uniqueConstraints:
         card_code_idx:
             columns: [ code ]

--- a/src/AppBundle/Resources/views/Search/card-front.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-front.html.twig
@@ -20,7 +20,7 @@
 				{% include 'AppBundle:Search:card-illustrator.html.twig' %}
 				{% include 'AppBundle:Search:card-pack.html.twig' %}
 				{% if card.erratum %}
-					<div style="margin-top: 2rem;"><i><b>Erratum:</b> {{card.erratum}}</i></div>
+					<div style="margin-top: 2rem;"><i><b>Erratum</b>: {{card.erratum}}</i></div>
 				{% endif %}
 			</div>
 		</div>

--- a/src/AppBundle/Resources/views/Search/card-front.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-front.html.twig
@@ -19,6 +19,9 @@
 				{% endif %}
 				{% include 'AppBundle:Search:card-illustrator.html.twig' %}
 				{% include 'AppBundle:Search:card-pack.html.twig' %}
+				{% if card.erratum %}
+					<div style="margin-top: 2rem;"><i><b>Erratum:</b> {{card.erratum}}</i></div>
+				{% endif %}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION

With this new feature, when a card have an erratum, description changes are displayed at the bottom of the card text

the errata is added in the PR:
https://github.com/zzorba/marvelsdb-json-data/pull/575

here is a screen shot from a local environment:
![image](https://github.com/user-attachments/assets/1464bfe4-e45d-42d8-95fc-1b7e8ee4890b)