### PR TITLE
Consolidate "fancy_int" formatter and "format_integer"

### DIFF
--- a/src/AppBundle/Resources/views/macros.html.twig
+++ b/src/AppBundle/Resources/views/macros.html.twig
@@ -1,5 +1,5 @@
 {% macro format_integer(value, star, per_hero) %}
-{% if value is null %}{% if star != true %}&mdash;{% endif %}{% elseif value < 0 %}X{% else %}{{ value }}{% endif %}{% if per_hero %}<span class="icon icon-per_hero"></span>{% endif %}{% if star %}<span class="icon icon-star"></span>{% endif %}
+{% if value is null %}{% if star != true %}&mdash;{% endif %}{% elseif value < 0 %}X{% else %}{{ value }}{% endif %}{% if per_hero and value is not null %}<span class="icon icon-per_hero"></span>{% endif %}{% if star %}<span class="icon icon-star"></span>{% endif %}
 {% endmacro %}
 
 {% macro card_name_with_pack_no_link(card) %}


### PR DESCRIPTION
Use the same behaviour as the `fancy_int` formatter for the `format_integer` formatter

https://github.com/zzorba/marvelsdb/blob/61812878ad320978b45a96c6514e63d5be977bff/src/AppBundle/Resources/public/js/app.format.js#L22-L38

this also simplifies .json files: 
- no need to use `threat_fixed = true` when `threat = null`
- no need to use `base_threat_fixed = true` when `base_threat = null`
- no need to use `escalation_threat_fixed = true` when `escalation_threat = null`

fix https://github.com/zzorba/marvelsdb/issues/291

![image](https://github.com/user-attachments/assets/d480da83-52fd-4d39-996f-964c516a6e16)

this is linked to this comment: https://github.com/zzorba/marvelsdb-json-data/pull/579#discussion_r1921497695



