### PR TITLE
Support thwart property for attachments

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -988,6 +988,8 @@ class ImportStdCommand extends ContainerAwareCommand
 			'scheme_crisis',
 			'scheme_hazard',
 			'scheme_star',
+			'thwart',
+			'thwart_star',
 		];
 		foreach($optionalKeys as $key) {
 			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, FALSE);

--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -125,6 +125,9 @@ format.info = function info(card) {
 			if (card.scheme || card.scheme_star) {
 				text += '<div>Scheme: ' + (card.scheme > 0 ? '+' : '') + format.fancy_int(card.scheme, card.scheme_star) + '</div>';
 			}
+			if (card.thwart || card.thwart_star) {
+				text += '<div>Thwart: ' + (card.thwart > 0 ? '+' : '') + format.fancy_int(card.thwart, card.thwart_star) + '</div>';
+			}
 			break;
 		case 'villain':
 		case 'minion':

--- a/src/AppBundle/Resources/views/Search/card-props.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-props.html.twig
@@ -54,6 +54,9 @@
 	{% if (card.scheme is defined and card.scheme != 0) or (card.scheme_star) %}
 	  <div>{% trans %}Scheme{% endtrans %}: {% if card.scheme > 0 %}+{% endif %}{{ macros.format_integer(card.scheme, card.scheme_star) }}</div>
 	{% endif %}
+	{% if (card.thwart is defined and card.thwart != 0) or (card.thwart_star) %}
+	  <div>{% trans %}Thwart{% endtrans %}: {% if card.thwart > 0 %}+{% endif %}{{ macros.format_integer(card.thwart, card.thwart_star) }}</div>
+	{% endif %}
 {% elseif card.type_code == 'side_scheme' %}
 	<div>
 	{% trans %}Starting Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, null, not card.base_threat_fixed) }}.


### PR DESCRIPTION
It's quite rare but an attachment could  have a threat value:

[Psychic Inertia](https://marvelcdb.com/card/40173)
![image](https://github.com/user-attachments/assets/2a0db714-9b5a-46f5-9b8c-9bcd6fc73c05)

[Power Stone](https://marvelcdb.com/card/16149)
![image](https://github.com/user-attachments/assets/7a8767df-49e6-4682-9e55-e77763a46ed1)
