### PR TITLE
Support negative values

### DIFF
--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -23,7 +23,7 @@ format.resource = function resource(value, type, css) {
  * @memberof format
  */
 format.fancy_int = function fancy_int(num, star, per_hero) {
-	let string = (num != null ? (num < 0 ? "X" : num) : '—');
+	let string = (num != null ? (num === 99 ? "X" : num) : '—');
 	if (num != null && per_hero) {
 		string += '<span class="icon icon-per_hero" />';
 	}

--- a/src/AppBundle/Resources/views/macros.html.twig
+++ b/src/AppBundle/Resources/views/macros.html.twig
@@ -1,5 +1,5 @@
 {% macro format_integer(value, star, per_hero) %}
-{% if value is null %}{% if star != true %}&mdash;{% endif %}{% elseif value < 0 %}X{% else %}{{ value }}{% endif %}{% if per_hero %}<span class="icon icon-per_hero"></span>{% endif %}{% if star %}<span class="icon icon-star"></span>{% endif %}
+{% if value is null %}{% if star != true %}&mdash;{% endif %}{% elseif value == 99 %}X{% else %}{{ value }}{% endif %}{% if per_hero %}<span class="icon icon-per_hero"></span>{% endif %}{% if star %}<span class="icon icon-star"></span>{% endif %}
 {% endmacro %}
 
 {% macro card_name_with_pack_no_link(card) %}


### PR DESCRIPTION
use `99` instead of `-1` to display "X" on a card

fix https://github.com/zzorba/marvelsdb/issues/290

this dev goes along with https://github.com/zzorba/marvelsdb-json-data/pull/600

