### PR TITLE
Support remaining Agents of S.H.I.E.L.D. cards

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -232,6 +232,7 @@ class ImportStdCommand extends ContainerAwareCommand
 		}
 
 
+		$output->writeln("");
 		$output->writeln("Generate cards json.");
 		$doctrine = $this->getContainer()->get('doctrine');
 
@@ -764,6 +765,15 @@ class ImportStdCommand extends ContainerAwareCommand
 			if ($cleanName == "Player Side Scheme") {
 				$cleanName = "PlayerSideScheme";
 			}
+			if ($cleanName == "Evidence - Means") {
+				$cleanName = "EvidenceMeans";
+			}
+			if ($cleanName == "Evidence - Motive") {
+				$cleanName = "EvidenceMotive";
+			}
+			if ($cleanName == "Evidence - Opportunity") {
+				$cleanName = "EvidenceOpportunity";
+			}
 			$functionName = 'import' . $cleanName . 'Data';
 			$this->$functionName($entity, $data);
 		}
@@ -907,6 +917,21 @@ class ImportStdCommand extends ContainerAwareCommand
 		foreach($optionalKeys as $key) {
 			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, FALSE);
 		}
+	}
+
+	protected function importEvidenceMeansData(Card $card, $data)
+	{
+
+	}
+
+	protected function importEvidenceMotiveData(Card $card, $data)
+	{
+
+	}
+
+	protected function importEvidenceOpportunityData(Card $card, $data)
+	{
+
 	}
 
 	protected function importSideSchemeData(Card $card, $data)


### PR DESCRIPTION
This adds support for the remaining Agents of S.H.I.E.L.D. cards that are getting added on https://github.com/zzorba/marvelsdb-json-data/pull/608. There are new Evidence card types that are part of this box that needed import functions. Those cards only use text at the moment which is a default import so the functions are blank for now.

This box also added icons in card names for cards 50184a, 50184b, and 50184c ([energy], [mental], and [physical] icons). I tried running the `replaceSymbols` function on the card name property but because it always appears in an anchor tag, the raw `<span class="icon-energy" />` appears. Not sure if there's going to be a way to make that more accurate or not. For the time being, the placeholder text for the icons appear in the card name.

<img width="630" alt="Screenshot 2025-02-26 at 10 52 48 PM" src="https://github.com/user-attachments/assets/25875876-d03b-4ddd-9e3b-4075bdf192f0" />
