### PR TITLE
Add support for Black Panther cards

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -790,6 +790,8 @@ class ImportStdCommand extends ContainerAwareCommand
 	protected function importUpgradeData(Card $card, $data)
 	{
 		$optionalKeys = [
+			'scheme_acceleration',
+			'scheme_amplify',
 			'scheme_crisis',
 			'scheme_hazard',
 		];
@@ -897,6 +899,7 @@ class ImportStdCommand extends ContainerAwareCommand
 			'health_star',
 			'scheme',
 			'scheme_acceleration',
+			'scheme_amplify',
 			'scheme_hazard',
 			'scheme_star',
 		];


### PR DESCRIPTION
Black Panther (Shuri) has a minion cards that needs `scheme_amplify` set. We weren't importing that property for the minion card type. I added it there but I also updated the upgrade card type to include both `scheme_acceleration` and `scheme_amplify` since both were missing there. At this point, we might want to just add all 4 of the scheme_{icon} properties as optional properties to all cards but I didn't take it quite that far.