### PR TITLE
Add support for Falcon and Winter Soldier packs

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -509,6 +509,7 @@ class ImportStdCommand extends ContainerAwareCommand
 				'traits',
 				'text',
 				'cost',
+				'cost_per_hero',
 				'resource_physical',
 				'resource_mental',
 				'resource_energy',

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -28,6 +28,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 			'traits',
 			'text',
 			'cost',
+			'cost_per_hero',
 			'octgn_id',
 			'subname',
 			'deck_limit',
@@ -254,6 +255,11 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	 * @var integer
 	 */
 	private $cost;
+
+	/**
+	 * @var boolean
+	 */
+	private $costPerHero;
 
 	/**
 	 * @var string
@@ -687,6 +693,30 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	public function getCost()
 	{
 		return $this->cost;
+	}
+
+	/**
+	 * Set costPerHero
+	 *
+	 * @param boolean $costPerHero
+	 *
+	 * @return Card
+	 */
+	public function setCostPerHero($costPerHero)
+	{
+		$this->costPerHero = $costPerHero;
+
+		return $this;
+	}
+
+	/**
+	 * Get costPerHero
+	 *
+	 * @return boolean
+	 */
+	public function getCostPerHero()
+	{
+		return $this->costPerHero;
 	}
 
 	/**

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -101,6 +101,9 @@ AppBundle\Entity\Card:
         cost:
             type: smallint
             nullable: true
+        costPerHero:
+            type: boolean
+            nullable: true
         text:
             type: text
             nullable: true

--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -151,7 +151,7 @@ format.info = function info(card) {
 		case 'event':
 		case 'player_side_scheme':
 			if (card.type_code != 'resource') {
-				text += '<div>Cost: ' + format.fancy_int(card.cost) + '.</div>';
+				text += '<div>Cost: ' + format.fancy_int(card.cost, null, card.cost_per_hero) + '.</div>';
 			}
 			if (card.type_code == 'player_side_scheme') {
 				text += '<div>Threat: ' + format.fancy_int(card.base_threat, null, !card.base_threat_fixed) + '.</div>';

--- a/src/AppBundle/Resources/views/Search/card-props.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-props.html.twig
@@ -6,7 +6,7 @@
 
 {% if card.type_code == 'upgrade' or card.type_code == 'event' or card.type_code == 'support' or card.type_code == 'ally' %}
 <div class="card-props">
-	{% trans %}Cost{% endtrans %}: {{ macros.format_integer(card.cost) }}.
+	{% trans %}Cost{% endtrans %}: {{ macros.format_integer(card.cost, null, card.cost_per_hero) }}.
 	{% if card.type_code == 'ally' %}
 	<div>
 	{% trans %}Health{% endtrans %}: {{ macros.format_integer(card.health, card.health_star) }}.


### PR DESCRIPTION
The Falcon hero pack includes some cards that need `cost_per_hero` defined. This property has already been used in the JSON repo but it isn't supported here yet. There are existing cards in other packs that use a variable cost based on the number of heroes in the game.

I'm adding a new `cost_per_hero` nullable boolean column to the `Card` table.
```sql
ALTER TABLE card ADD cost_per_hero TINYINT(1) DEFAULT NULL;
```

I verified the JSON data can be inserted into this column properly and we can display the cost with a per_hero icon in this situation.

<img width="495" alt="Screenshot 2025-05-14 at 10 18 13 PM" src="https://github.com/user-attachments/assets/18d3f7c9-7151-4c2a-bbb3-819c31c4108c" />
<img width="491" alt="Screenshot 2025-05-14 at 10 18 43 PM" src="https://github.com/user-attachments/assets/abc0631b-ce0d-4c8b-a28d-45552f12ab6f" />
<img width="499" alt="Screenshot 2025-05-14 at 10 17 38 PM" src="https://github.com/user-attachments/assets/36db3ae0-2c5f-4a07-9dc3-57f5810139e9" />
<img width="500" alt="Screenshot 2025-05-14 at 10 18 28 PM" src="https://github.com/user-attachments/assets/58793c1e-5402-46c7-ada0-95056124e566" />
