### PR TITLE
Convert stage to a string column

### DIFF
--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -408,7 +408,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	private $restrictions;
 
 	/**
-	 * @var integer
+	 * @var string
 	 */
 	private $stage;
 
@@ -1234,7 +1234,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	/**
 	 * Set stage
 	 *
-	 * @param integer $stage
+	 * @param string $stage
 	 *
 	 * @return Card
 	 */
@@ -1248,7 +1248,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	/**
 	 * Get stage
 	 *
-	 * @return integer
+	 * @return string
 	 */
 	public function getStage()
 	{

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -215,7 +215,8 @@ AppBundle\Entity\Card:
             nullable: true
             column: deck_limit
         stage:
-            type: smallint
+            type: string
+            length: 4
             nullable: true
         traits:
             type: string

--- a/src/AppBundle/Resources/public/js/app.tip.js
+++ b/src/AppBundle/Resources/public/js/app.tip.js
@@ -9,16 +9,13 @@ function getCardText(card) {
 	var content = image
 	+ '<h4 class="card-name">' + app.format.name(card) + '</h4>'
 	+ '<div class="card-faction">' + app.format.faction(card) + '</div>'
-	+ '<div><span class="card-type">' + card.type_name + (card.stage && (card.type_code == "main_scheme" || card.type_code == 'villain') ? '. Stage ' + card.stage : '') + (card.subtype_name ? '. ' + card.subtype_name : "") + '</span></div>'
+	+ '<div><span class="card-type">' + card.type_name + '.' + (card.stage && (card.type_code == "main_scheme" || card.type_code == 'villain') ? ' Stage ' + card.stage + '.' : '') + '</span></div>'
 	+ '<div class="card-traits">' + app.format.traits(card) + '</div>'
 	;
 
 
 	content += '<div class="card-info">' + app.format.info(card) + '</div>';
 	if (card.double_sided){
-//		if (card.back_flavor){
-//			content += '<div class="card-flavor">' + card.back_flavor + '</div>';
-//		}
 		if (card.back_text){
 			content += '<div class="card-text border-'+card.faction_code+'">' + app.format.back_text(card) + '</div>';
 			content += '<hr />'

--- a/src/AppBundle/Resources/views/Search/card-info.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-info.html.twig
@@ -1,4 +1,4 @@
 <div class="card-info{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %}" >
-	<span class="card-type">{{ card.type_name }}{% if card.stage %}. Stage {{card.stage}}{% endif %}{% if card.subtype_name is defined %}. {{card.subtype_name}}{% endif %}</span>
+	<span class="card-type">{{ card.type_name }}{% if card.stage %}. Stage {{card.stage}}.{% endif %}</span>
 	{% include 'AppBundle:Search:card-props.html.twig' %}
 </div>

--- a/src/AppBundle/Resources/views/Search/card-stage.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-stage.html.twig
@@ -1,5 +1,5 @@
 {% if card.type_code == 'villain' and card.stage %}
- {% if card.stage == 1 %}(I){% elseif card.stage == 2 %}(II){% elseif card.stage == 3 %}(III){% elseif card.stage == 4 %}(IV){% elseif card.stage == 5 %}(V){% else %}({{ card.stage }}){% endif %}
+ ({{card.stage}})
 {% elseif card.type_code == 'main_scheme' %}
-  - {{ card.stage }}{% if card.linked_card is defined %}A{% else %}B{% endif %}
+  - {{ card.stage }}
 {% endif %}


### PR DESCRIPTION
The `stage` column is a integer column but it can't handle values like "A", "B1", "III", etc. This PR converts it to a string column so that we correctly display all stage values that villain and main_scheme cards might have.

```sql
ALTER TABLE card CHANGE stage stage VARCHAR(4) DEFAULT NULL;
```

I removed some code related to `subtype_name`. I couldn't find that referenced anywhere so it looked like dead code to me.

Here are some examples of cards that we can now support.

[Arclight - 40070a](https://marvelcdb.com/card/40070a)
<img width="397" alt="Screenshot 2025-06-25 at 10 11 59 PM" src="https://github.com/user-attachments/assets/1d8ea64c-0c48-4bd3-a21c-316b4c39e0b7" />

[Knock, Knock - 40077](https://marvelcdb.com/card/40077)
<img width="395" alt="Screenshot 2025-06-25 at 10 12 20 PM" src="https://github.com/user-attachments/assets/7893721b-60bc-4308-8c7e-a6b0f566e50a" />

[Hela - 21136a](https://marvelcdb.com/card/21136a)
<img width="397" alt="Screenshot 2025-06-25 at 10 12 42 PM" src="https://github.com/user-attachments/assets/1b4b5ab4-001e-46ef-a77d-0c0a238dcb28" />

[Skies Over New York - 27116a](https://marvelcdb.com/card/27116a)
<img width="394" alt="Screenshot 2025-06-25 at 10 13 10 PM" src="https://github.com/user-attachments/assets/336ebf88-4825-49b8-b880-eda25825ba8f" />
