### PR TITLE
Add support for Civil War

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -1036,6 +1036,29 @@ class ImportStdCommand extends ContainerAwareCommand
 		}
 	}
 
+	protected function importLeaderData(Card $card, $data)
+	{
+		$mandatoryKeys = [
+			'health',
+		];
+		foreach($mandatoryKeys as $key) {
+			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, TRUE);
+		}
+
+		$optionalKeys = [
+			'attack',
+			'attack_star',
+			'health_per_hero',
+			'health_star',
+			'scheme',
+			'scheme_star',
+			'stage',
+		];
+		foreach($optionalKeys as $key) {
+			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, FALSE);
+		}
+	}
+
 	protected function importTreacheryData(Card $card, $data)
 	{
 		$optionalKeys = [

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -131,6 +131,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 				$optionalFields[] = 'scheme';
 				$optionalFields[] = 'scheme_star';
 				break;
+			case "leader":
 			case "villain":
 				$optionalFields[] = 'attack';
 				$optionalFields[] = 'attack_star';

--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -48,7 +48,7 @@ format.stage = function stage(card) {
  */
 format.name = function name(card) {
 	var name = (card.is_unique ? '<span class="icon-unique"></span> ' : "") + card.name;
-	if (card.type_code == 'villain' && card.stage) {
+	if ((card.type_code == 'villain' || card.type_code == 'leader') && card.stage) {
 		var stages = ['0', 'I', 'II', 'III', 'IV', 'V'];
 		name += ' (' + (stages[card.stage] || card.stage) + ')';
 	}
@@ -126,6 +126,7 @@ format.info = function info(card) {
 				text += '<div>Scheme: ' + (card.scheme > 0 ? '+' : '') + format.fancy_int(card.scheme, card.scheme_star) + '</div>';
 			}
 			break;
+		case 'leader':
 		case 'villain':
 		case 'minion':
 				text += '<div>Attack: ' + format.fancy_int(card.attack, card.attack_star);

--- a/src/AppBundle/Resources/public/js/app.tip.js
+++ b/src/AppBundle/Resources/public/js/app.tip.js
@@ -9,7 +9,7 @@ function getCardText(card) {
 	var content = image
 	+ '<h4 class="card-name">' + app.format.name(card) + '</h4>'
 	+ '<div class="card-faction">' + app.format.faction(card) + '</div>'
-	+ '<div><span class="card-type">' + card.type_name + '.' + (card.stage && (card.type_code == "main_scheme" || card.type_code == 'villain') ? ' Stage ' + card.stage + '.' : '') + '</span></div>'
+	+ '<div><span class="card-type">' + card.type_name + '.' + (card.stage && (card.type_code == "main_scheme" || card.type_code == 'villain' || card.type_code == 'leader') ? ' Stage ' + card.stage + '.' : '') + '</span></div>'
 	+ '<div class="card-traits">' + app.format.traits(card) + '</div>'
 	;
 

--- a/src/AppBundle/Resources/views/Search/card-props.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-props.html.twig
@@ -41,7 +41,7 @@
 	<div>
 		{% trans %}Health{% endtrans %}: {{ macros.format_integer(card.health, card.health_star) }}. {% trans %}Hand Size{% endtrans %}: {{ macros.format_integer(card.hand_size) }}.
 	</div>
-{% elseif card.type_code == 'minion' or card.type_code == 'villain' %}
+{% elseif card.type_code == 'minion' or card.type_code == 'villain' or card.type_code == 'leader' %}
 	<div>
 	{% trans %}Attack{% endtrans %}: {{ macros.format_integer(card.attack, card.attack_star) }}.
 	{% trans %}Scheme{% endtrans %}: {{ macros.format_integer(card.scheme, card.scheme_star) }}.

--- a/src/AppBundle/Resources/views/Search/card-stage.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-stage.html.twig
@@ -1,4 +1,4 @@
-{% if card.type_code == 'villain' and card.stage %}
+{% if (card.type_code == 'villain' or card.type_code == 'leader') and card.stage %}
  ({{card.stage}})
 {% elseif card.type_code == 'main_scheme' %}
   - {{ card.stage }}

--- a/src/AppBundle/Resources/views/Search/display-list.html.twig
+++ b/src/AppBundle/Resources/views/Search/display-list.html.twig
@@ -21,7 +21,7 @@
 	<td data-th="Name">
 		<span class="icon icon-{{ card.type_code}} fg-{{ card.faction_code }}"></span>
 		<a href="{{ card.url }}" class="{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %} card-tip{% if card.available == false %} card-preview{% endif %}" data-code="{{ card.code }}">
-		{{ card.name }}{% if card.type_code == 'villain' %}{% include 'AppBundle:Search:card-stage.html.twig' %}{% endif %}{% if card.subname%}: {{ card.subname }}{% endif %}</a>
+		{{ card.name }}{% if card.type_code == 'villain' or card.type_code == 'leader' %}{% include 'AppBundle:Search:card-stage.html.twig' %}{% endif %}{% if card.subname%}: {{ card.subname }}{% endif %}</a>
 	</td>
 	<td data-th="Faction" style="width : 100px;" class="fg-{{ card.faction_code }}"><span class="icon-{{card.faction_code}}"></span>{% if card.faction2_code is defined %}<span class="icon-{{card.faction2_code}}"></span> {% else %} {{ card.faction_name }} {% endif %}  </td>
 	<td data-th="Cost" style="width : 30px;">{{ card.cost }}</td>


### PR DESCRIPTION
This adds support for the new "leader" card type. This type is basically the same as the existing "villain" card type.

This code is needed for https://github.com/zzorba/marvelsdb-json-data/pull/652 to get merged.