### PR TITLE
Fix 500 error on decklists/by_date for days with no decklists

### DIFF
--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -591,9 +591,13 @@ class ApiController extends Controller
 			return $decklist->getDateUpdate();
 		})->toArray();
 
-		$response->setLastModified(max($dateUpdates));
-		if ($response->isNotModified($request)) {
-			return $response;
+		// max() fails on an empty array, so only handle Last-Modified when
+		// the day has decklists; an empty day returns an empty array below
+		if (count($dateUpdates)) {
+			$response->setLastModified(max($dateUpdates));
+			if ($response->isNotModified($request)) {
+				return $response;
+			}
 		}
 
 		$content = json_encode($decklists->toArray());


### PR DESCRIPTION
listDecklistsByDateAction computed max() over the decklists' update dates to set the Last-Modified header, but max() fails on an empty array, so any date with zero published decklists returned HTTP 500 instead of an empty result. Skip the Last-Modified handling when the day is empty and return an empty JSON array with status 200.