### PR TITLE
Include like/favorite/comment counts in decklist API output

### DIFF
--- a/src/AppBundle/Entity/Decklist.php
+++ b/src/AppBundle/Entity/Decklist.php
@@ -48,6 +48,9 @@ class Decklist extends \AppBundle\Model\ExportableDeck implements \JsonSerializa
 	public function jsonSerialize()
 	{
 		$array = parent::getArrayExport();
+		$array['like_count'] = $this->getnbVotes();
+		$array['favorite_count'] = $this->getNbFavorites();
+		$array['comment_count'] = $this->getNbComments();
 
 		return $array;
 	}


### PR DESCRIPTION
The decklist social counters (nb_votes, nb_favorites, nb_comments) are shown on the site but were never included in the public API responses (/api/public/decklist/{id} and /api/public/decklists/by_date/{date}), so API consumers had no way to read a decklist's popularity.