### PR TITLE
Add support for Fear No Evil

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -526,6 +526,7 @@ class ImportStdCommand extends ContainerAwareCommand
 				'text',
 				'cost',
 				'cost_per_hero',
+				'cost_star',
 				'resource_physical',
 				'resource_mental',
 				'resource_energy',

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -29,6 +29,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 			'text',
 			'cost',
 			'cost_per_hero',
+			'cost_star',
 			'octgn_id',
 			'subname',
 			'deck_limit',
@@ -267,6 +268,11 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	 * @var boolean
 	 */
 	private $costPerHero;
+
+	/**
+	 * @var boolean
+	 */
+	private $costStar;
 
 	/**
 	 * @var string
@@ -734,6 +740,30 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	public function getCostPerHero()
 	{
 		return $this->costPerHero;
+	}
+
+	/**
+	 * Set costStar
+	 *
+	 * @param boolean $costStar
+	 *
+	 * @return Card
+	 */
+	public function setCostStar($costStar)
+	{
+		$this->costStar = $costStar;
+
+		return $this;
+	}
+
+	/**
+	 * Get costStar
+	 *
+	 * @return boolean
+	 */
+	public function getCostStar()
+	{
+		return $this->costStar;
 	}
 
 	/**

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -104,6 +104,9 @@ AppBundle\Entity\Card:
         costPerHero:
             type: boolean
             nullable: true
+        costStar:
+            type: boolean
+            nullable: true
         text:
             type: text
             nullable: true

--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -153,7 +153,7 @@ format.info = function info(card) {
 		case 'event':
 		case 'player_side_scheme':
 			if (card.type_code != 'resource') {
-				text += '<div>Cost: ' + format.fancy_int(card.cost, null, card.cost_per_hero) + '.</div>';
+				text += '<div>Cost: ' + format.fancy_int(card.cost, card.cost_star, card.cost_per_hero) + '.</div>';
 			}
 			if (card.type_code == 'player_side_scheme') {
 				text += '<div>Threat: ' + format.fancy_int(card.base_threat, null, !card.base_threat_fixed && !card.base_threat_per_group, card.base_threat_per_group) + '.</div>';

--- a/src/AppBundle/Resources/views/Search/card-props.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-props.html.twig
@@ -6,7 +6,7 @@
 
 {% if card.type_code == 'upgrade' or card.type_code == 'event' or card.type_code == 'support' or card.type_code == 'ally' %}
 <div class="card-props">
-	{% trans %}Cost{% endtrans %}: {{ macros.format_integer(card.cost, null, card.cost_per_hero) }}.
+	{% trans %}Cost{% endtrans %}: {{ macros.format_integer(card.cost, card.cost_star, card.cost_per_hero) }}.
 	{% if card.type_code == 'ally' %}
 	<div>
 	{% trans %}Health{% endtrans %}: {{ macros.format_integer(card.health, card.health_star) }}.


### PR DESCRIPTION
The Civil War expansion added a new type of card that has a star next to the cost.

[Hunted](https://marvelcdb.com/find?q=56007)

The JSON repo added `cost_star` as a property but that wasn't added to this repo yet to support that property on the backend. This PR adds that support by adding a new column to the `card` table and allowing that property to be imported and displayed properly.

```sql
ALTER TABLE card ADD cost_star TINYINT(1) DEFAULT NULL;
```

<img width="394" height="304" alt="Screenshot 2026-07-22 at 11 20 31 PM" src="https://github.com/user-attachments/assets/d539855d-2304-4421-a1eb-d652facc678e" />
<img width="398" height="286" alt="Screenshot 2026-07-22 at 11 20 11 PM" src="https://github.com/user-attachments/assets/26de9e07-22d1-4d35-8a11-bdb049433abc" />
