### PR TITLE
Add support for Jessica Jones and Luke Cage

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -961,6 +961,7 @@ class ImportStdCommand extends ContainerAwareCommand
 			'base_threat',
 			'base_threat_fixed',
 			'base_threat_per_group',
+			'base_threat_star',
 			'boost',
 			'boost_star',
 			'escalation_threat',
@@ -982,6 +983,7 @@ class ImportStdCommand extends ContainerAwareCommand
 			'base_threat',
 			'base_threat_fixed',
 			'base_threat_per_group',
+			'base_threat_star',
 			'escalation_threat',
 			'escalation_threat_fixed',
 			'escalation_threat_star',
@@ -1012,6 +1014,7 @@ class ImportStdCommand extends ContainerAwareCommand
 		$optionalKeys = [
 			'base_threat_fixed',
 			'base_threat_per_group',
+			'base_threat_star',
 			'scheme_acceleration',
 			'scheme_amplify',
 			'scheme_crisis',

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -76,6 +76,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 				$mandatoryFields[] = 'base_threat';
 				$optionalFields[] = 'base_threat_fixed';
 				$optionalFields[] = 'base_threat_per_group';
+				$optionalFields[] = 'base_threat_star';
 				$optionalFields[] = 'resource_energy';
 				$optionalFields[] = 'resource_physical';
 				$optionalFields[] = 'resource_mental';
@@ -161,6 +162,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 				$optionalFields[] = 'base_threat';
 				$optionalFields[] = 'base_threat_fixed';
 				$optionalFields[] = 'base_threat_per_group';
+				$optionalFields[] = 'base_threat_star';
 				$optionalFields[] = 'boost';
 				$optionalFields[] = 'boost_star';
 				$optionalFields[] = 'escalation_threat';
@@ -176,6 +178,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 				$optionalFields[] = 'base_threat';
 				$optionalFields[] = 'base_threat_fixed';
 				$optionalFields[] = 'base_threat_per_group';
+				$optionalFields[] = 'base_threat_star';
 				$optionalFields[] = 'escalation_threat';
 				$optionalFields[] = 'escalation_threat_fixed';
 				$optionalFields[] = 'escalation_threat_star';
@@ -2439,6 +2442,11 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
     private $baseThreatPerGroup;
 
     /**
+     * @var boolean
+     */
+    private $baseThreatStar;
+
+    /**
      * @var integer
      */
     private $escalationThreat;
@@ -2544,6 +2552,30 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
     public function getBaseThreatPerGroup()
     {
         return $this->baseThreatPerGroup;
+    }
+
+    /**
+     * Set baseThreatStar
+     *
+     * @param boolean $baseThreatStar
+     *
+     * @return Card
+     */
+    public function setBaseThreatStar($baseThreatStar)
+    {
+        $this->baseThreatStar = $baseThreatStar;
+
+        return $this;
+    }
+
+    /**
+     * Get baseThreatStar
+     *
+     * @return boolean
+     */
+    public function getBaseThreatStar()
+    {
+        return $this->baseThreatStar;
     }
 
     /**

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -195,6 +195,9 @@ AppBundle\Entity\Card:
         baseThreatPerGroup:
             type: boolean
             nullable: true
+        baseThreatStar:
+            type: boolean
+            nullable: true
         escalationThreat:
             type: smallint
             nullable: true

--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -107,7 +107,7 @@ format.info = function info(card) {
 	switch(card.type_code) {
 		case 'side_scheme':
 		case 'main_scheme':
-			text += '<div>Starting Threat: ' + format.fancy_int(card.base_threat, null, !card.base_threat_fixed && !card.base_threat_per_group, card.base_threat_per_group) + '.';
+			text += '<div>Starting Threat: ' + format.fancy_int(card.base_threat, card.base_threat_star, !card.base_threat_fixed && !card.base_threat_per_group, card.base_threat_per_group) + '.';
 			if (card.type_code == 'main_scheme') {
 				if (card.escalation_threat || card.escalation_threat_star) {
 					text += ' Escalation Threat: ' + format.fancy_int(card.escalation_threat, card.escalation_threat_star, !card.escalation_threat_fixed) + '.</div>';
@@ -156,7 +156,7 @@ format.info = function info(card) {
 				text += '<div>Cost: ' + format.fancy_int(card.cost, card.cost_star, card.cost_per_hero) + '.</div>';
 			}
 			if (card.type_code == 'player_side_scheme') {
-				text += '<div>Threat: ' + format.fancy_int(card.base_threat, null, !card.base_threat_fixed && !card.base_threat_per_group, card.base_threat_per_group) + '.</div>';
+				text += '<div>Threat: ' + format.fancy_int(card.base_threat, card.base_threat_star, !card.base_threat_fixed && !card.base_threat_per_group, card.base_threat_per_group) + '.</div>';
 			}
 			if (card.resource_physical || card.resource_mental || card.resource_energy || card.resource_wild){
 				text += '<div>Resource: ';

--- a/src/AppBundle/Resources/views/Search/card-props.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-props.html.twig
@@ -23,7 +23,7 @@
 <div class="card-props">
   {% trans %}Cost{% endtrans %}: {{ macros.format_integer(card.cost) }}.
 	<div>
-		{% trans %}Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, null, not card.base_threat_fixed and not card.base_threat_per_group, card.base_threat_per_group) }}.
+		{% trans %}Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, card.base_threat_star, not card.base_threat_fixed and not card.base_threat_per_group, card.base_threat_per_group) }}.
 	</div>
 </div>
 {% endif %}
@@ -56,7 +56,7 @@
 	{% endif %}
 {% elseif card.type_code == 'side_scheme' %}
 	<div>
-	{% trans %}Starting Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, null, not card.base_threat_fixed and not card.base_threat_per_group, card.base_threat_per_group) }}.
+	{% trans %}Starting Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, card.base_threat_star, not card.base_threat_fixed and not card.base_threat_per_group, card.base_threat_per_group) }}.
 	{% if card.escalation_threat %}
 		{% trans %}Escalation Threat{% endtrans %}: {{ macros.format_integer(card.escalation_threat, card.escalation_threat_star, not card.escalation_threat_fixed) }}.
 	{% endif %}
@@ -64,7 +64,7 @@
 {% elseif card.type_code == 'main_scheme' %}
 	{% if card.linked_card is not defined %}
 	<div>
-	{% trans %}Starting Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, null, not card.base_threat_fixed and not card.base_threat_per_group, card.base_threat_per_group) }}.
+	{% trans %}Starting Threat{% endtrans %}: {{ macros.format_integer(card.base_threat, card.base_threat_star, not card.base_threat_fixed and not card.base_threat_per_group, card.base_threat_per_group) }}.
 	{% if card.escalation_threat %}
 		{% trans %}Escalation Threat{% endtrans %}: {{ macros.format_integer(card.escalation_threat, card.escalation_threat_star, not card.escalation_threat_fixed) }}.
 	{% endif %}


### PR DESCRIPTION
Add support for Jessica Jones and Luke Cage by adding a new `base_threat_star` column to the `card` table.

```sql
ALTER TABLE card ADD base_threat_star TINYINT(1) DEFAULT NULL;
```

This column allows us to tag base threats with a star symbol for main scheme/side scheme/player side schemes.

I verified this works with some of the new player side scheme cards in the Jessica Jones pack.

<img width="394" height="310" alt="Screenshot 2026-08-11 at 9 05 54 PM" src="https://github.com/user-attachments/assets/de42a593-5e49-40d4-8739-92da52d54d25" />

